### PR TITLE
WIP: Fix JSStringRef_type_conversion error compiling with gcc7

### DIFF
--- a/recipes-browser/wpewebkit/wpewebkit/fix_API_JSStringRef_type_conversion.patch
+++ b/recipes-browser/wpewebkit/wpewebkit/fix_API_JSStringRef_type_conversion.patch
@@ -1,0 +1,54 @@
+diff -ruN git/Source/JavaScriptCore/API/JSStringRef.cpp git.patched/Source/JavaScriptCore/API/JSStringRef.cpp
+--- git/Source/JavaScriptCore/API/JSStringRef.cpp       2018-02-27 16:47:25.182835822 +0100
++++ git.patched/Source/JavaScriptCore/API/JSStringRef.cpp       2018-02-27 16:58:07.649218536 +0100
+@@ -37,7 +37,7 @@
+ JSStringRef JSStringCreateWithCharacters(const JSChar* chars, size_t numChars)
+ {
+     initializeThreading();
+-    return &OpaqueJSString::create(chars, numChars).leakRef();
++    return &OpaqueJSString::create(reinterpret_cast<const UChar*>(chars), numChars).leakRef();
+ }
+
+ JSStringRef JSStringCreateWithUTF8CString(const char* string)
+@@ -62,7 +62,7 @@
+ JSStringRef JSStringCreateWithCharactersNoCopy(const JSChar* chars, size_t numChars)
+ {
+     initializeThreading();
+-    return OpaqueJSString::create(StringImpl::createWithoutCopying(chars, numChars)).leakRef();
++    return OpaqueJSString::create(StringImpl::createWithoutCopying(reinterpret_cast<const UChar*>(chars), numChars)).leakRef();
+ }
+
+ JSStringRef JSStringRetain(JSStringRef string)
+@@ -87,7 +87,7 @@
+ {
+     if (!string)
+         return nullptr;
+-    return string->characters();
++    return reinterpret_cast<const JSChar*>(string->characters());
+ }
+
+ size_t JSStringGetMaximumUTF8CStringSize(JSStringRef string)
+diff -ruN git/Source/JavaScriptCore/runtime/DateConversion.cpp git.patched/Source/JavaScriptCore/runtime/DateConversion.cpp
+--- git/Source/JavaScriptCore/runtime/DateConversion.cpp        2018-02-27 16:47:25.182835822 +0100
++++ git.patched/Source/JavaScriptCore/runtime/DateConversion.cpp        2018-02-27 16:59:22.741504563 +0100
+@@ -107,7 +107,8 @@
+ #if OS(WINDOWS)
+             TIME_ZONE_INFORMATION timeZoneInformation;
+             GetTimeZoneInformation(&timeZoneInformation);
+-            const WCHAR* timeZoneName = t.isDST() ? timeZoneInformation.DaylightName : timeZoneInformation.StandardName;
++            const WCHAR* winTimeZoneName = t.isDST() ? timeZoneInformation.DaylightName : timeZoneInformation.StandardName;
++            String timeZoneName(reinterpret_cast<const UChar*>(winTimeZoneName));
+ #else
+             struct tm gtm = t;
+             char timeZoneName[70];
+diff -ruN git/Source/WebKit2/Shared/API/c/WKString.cpp git.patched/Source/WebKit2/Shared/API/c/WKString.cpp
+--- git/Source/WebKit2/Shared/API/c/WKString.cpp        2018-02-27 16:47:25.182835822 +0100
++++ git.patched/Source/WebKit2/Shared/API/c/WKString.cpp        2018-02-27 17:01:07.673903932 +0100
+@@ -61,7 +61,7 @@
+     unsigned unsignedBufferLength = std::min<size_t>(bufferLength, std::numeric_limits<unsigned>::max());
+     auto substring = toImpl(stringRef)->stringView().substring(0, unsignedBufferLength);
+
+-    substring.getCharactersWithUpconvert(static_cast<UChar*>(buffer));
++    substring.getCharactersWithUpconvert(reinterpret_cast<UChar*>(buffer));
+     return substring.length();
+ }

--- a/recipes-browser/wpewebkit/wpewebkit/fix_JSStringRef_type_conversion.patch
+++ b/recipes-browser/wpewebkit/wpewebkit/fix_JSStringRef_type_conversion.patch
@@ -1,0 +1,19 @@
+--- wpewebkit-1.20170926-r0.orig/Source/JavaScriptCore/API/JSStringRef.h	2016-02-27 11:14:00.000000000 +0100
++++ wpewebkit-1.20170926-r0/Source/JavaScriptCore/API/JSStringRef.h	2017-02-27 11:14:05.000000000 +0100
+@@ -27,6 +27,7 @@
+ #define JSStringRef_h
+
+ #include <JavaScriptCore/JSValueRef.h>
++#include <uchar.h>
+
+ #ifndef __cplusplus
+ #include <stdbool.h>
+@@ -46,7 +47,7 @@
+  character. As with all scalar types, endianness depends on the underlying
+  architecture.
+ */
+-    typedef unsigned short JSChar;
++    typedef char16_t JSChar;
+ #else
+     typedef wchar_t JSChar;
+ #endif

--- a/recipes-browser/wpewebkit/wpewebkit/fix_WKString_type_conversion.patch
+++ b/recipes-browser/wpewebkit/wpewebkit/fix_WKString_type_conversion.patch
@@ -1,0 +1,19 @@
+--- webkitgtk-2.4.11.orig/Source/WebKit2/Shared/API/c/WKString.h.orig   2017-12-17 20:37:47.918238974 +0100
++++ webkitgtk-2.4.11.orig/Source/WebKit2/Shared/API/c/WKString.h        2017-12-17 20:39:10.970532449 +0100
+@@ -28,6 +28,7 @@
+ 
+ #include <WebKit2/WKBase.h>
+ #include <stddef.h>
++#include <uchar.h>
+ 
+ #ifndef __cplusplus
+ #include <stdbool.h>
+@@ -39,7 +40,7 @@
+ 
+ #if !defined(WIN32) && !defined(_WIN32) \
+     && !((defined(__CC_ARM) || defined(__ARMCC__)) && !defined(__linux__)) /* RVCT */
+-    typedef unsigned short WKChar;
++    typedef char16_t WKChar;
+ #else
+     typedef wchar_t WKChar;
+ #endif

--- a/recipes-browser/wpewebkit/wpewebkit/fix_WebEventFactory.patch
+++ b/recipes-browser/wpewebkit/wpewebkit/fix_WebEventFactory.patch
@@ -1,0 +1,20 @@
+[WPE] Build failure with Clang 4.0.1: no matching conversion for functional-style cast from 'pointer' (aka 'unsigned short *') to 'WTF::String'
+https://bugs.webkit.org/show_bug.cgi?id=175477
+
+Reviewed by Žan Doberšek.
+
+* Shared/wpe/WebEventFactory.cpp:
+  (WebKit::singleCharacterStringForKeyEvent): Cast to UChar* to make
+  compiler choose the correct WTF::String constructor.
+
+(revision 223544)
+
+--- webkitgtk/Source/WebKit2/Shared/wpe/WebEventFactory.cpp.orig   2017-12-17 20:37:47.918238974 +0100
++++ webkitgtk/Source/WebKit2/Shared/wpe/WebEventFactory.cpp        2017-12-17 20:39:10.970532449 +0100
+@@ -60,5 +60,5 @@
+     GUniquePtr<gunichar2> uchar16(g_ucs4_to_utf16(&event->unicode, 1, 0, &length, nullptr));
+     if (uchar16)
+-        return String(uchar16.get());
++        return String(reinterpret_cast<UChar*>(uchar16.get()), length);
+     return String();
+ }

--- a/recipes-browser/wpewebkit/wpewebkit_git.bb
+++ b/recipes-browser/wpewebkit/wpewebkit_git.bb
@@ -21,6 +21,10 @@ SRC_URI = " git://github.com/WebPlatformForEmbedded/WPEWebKit.git;protocol=https
             file://0001-WebKitMacros-Append-to-I-and-not-to-isystem.patch \
             file://0001-WPE-Some-event-handlers-not-working.patch \
             file://revert_image_decoders-198781.patch \
+            file://fix_JSStringRef_type_conversion.patch \
+            file://fix_WKString_type_conversion.patch \
+            file://fix_API_JSStringRef_type_conversion.patch \
+            file://fix_WebEventFactory.patch \
           "
 
 S = "${WORKDIR}/git"


### PR DESCRIPTION
```
error: invalid conversion from ‘const UChar* {aka const char16_t*}’ to ‘const JSChar* {aka const short unsigned int*}’ [-fpermissive]
```

The patch is based on the original bugfix for webkitgtk on Gentoo: https://bugs.gentoo.org/621532

Status: **WIP**

* This patch is tested in a `rocko` naive environment
* ~~TODO: test if also works in `pyro`~~ **Tested**

Signed-off-by: Pablo Saavedra <psaavedra at igalia.com>