### PR TITLE
dyz uses luajit of the sysroot in the build step

### DIFF
--- a/recipes-browser/dyz/dyz_0.1.bb
+++ b/recipes-browser/dyz/dyz_0.1.bb
@@ -4,7 +4,9 @@ DEPENDS = "wpewebkit glib-2.0 luajit-native luajit"
 RDEPENDS_${PN} = "glib-2.0-dev wpewebkit-dev"
 
 SRCREV = "ec7a8b93e2c6afb04a7f7feb76d28bfddffaaea0"
-SRC_URI = "git://github.com/Igalia/dyz.git;protocol=https;branch=master"
+SRC_URI = "git://github.com/Igalia/dyz.git;protocol=https;branch=master \
+           file://0001-Fixed-luajit-native-path.patch \
+"
 
 inherit autotools
 
@@ -14,3 +16,7 @@ B = "${S}"
 LDFLAGS="-ldl -lm"
 
 INSANE_SKIP_${PN} = "dev-deps"
+
+do_compile_prepend() {
+    export LUA_PATH="${RECIPE_SYSROOT_NATIVE}/usr/share/luajit-2.0.5/?.lua"
+}

--- a/recipes-browser/dyz/files/0001-Fixed-luajit-native-path.patch
+++ b/recipes-browser/dyz/files/0001-Fixed-luajit-native-path.patch
@@ -1,0 +1,25 @@
+From 1e1870c0fe43f8a650b1a024af34937b9d341936 Mon Sep 17 00:00:00 2001
+From: Pablo Saavedra <psaavedra@igalia.com>
+Date: Tue, 13 Mar 2018 19:25:37 +0100
+Subject: [PATCH] Fixed luajit native path
+
+---
+ src/Makefile | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/Makefile b/src/Makefile
+index c9fe194..d25af51 100644
+--- a/src/Makefile
++++ b/src/Makefile
+@@ -47,7 +47,7 @@ CFLAGS  += $(LUAJIT_CFLAGS)
+ LDFLAGS += $(LUAJIT_LDLIBS)
+ 
+ ifeq ($(strip $(LUAJIT)),)
+-  LUAJIT := $(shell pkg-config luajit --variable=prefix)/bin/luajit
++  LUAJIT := $(PKG_CONFIG_SYSROOT_DIR)-native$(shell pkg-config luajit --variable=prefix)/bin/luajit
+ endif
+ 
+ all: dyz
+-- 
+2.11.0
+


### PR DESCRIPTION
* without this patch recipe fails if luajit is not present in the
  build system

Signed-off-by: Pablo Saavedra <psaavedra@igalia.com>