### PR TITLE
Add core-image-wpe-crosscompilation recipe

### DIFF
--- a/recipes-browser/images/core-image-wpe-crosscompilation.bb
+++ b/recipes-browser/images/core-image-wpe-crosscompilation.bb
@@ -1,0 +1,10 @@
+SUMMARY = "WPE cross-compilation image, using ARM Traditional ISA."
+
+LICENSE = "BSD"
+
+inherit core-image distro_features_check
+
+REQUIRED_DISTRO_FEATURES = "wayland"
+
+PREFERRED_PROVIDER_virtual/wpebackend = "wpebackend-fdo"
+CORE_IMAGE_BASE_INSTALL += "wpebackend-fdo wpewebkit"


### PR DESCRIPTION
Add the core-image-wpe-crosscompilation recipe that can be used to generate
a minimal wpewebkit build that can then be used for cross-compilation by
generating the SDK for this image and using it with WebKit ToT builds.