### PR TITLE
webkitgtk: upgrade to 2.20.3

### DIFF
--- a/recipes-browser/webkitgtk/webkitgtk_2.20.3.bb
+++ b/recipes-browser/webkitgtk/webkitgtk_2.20.3.bb
@@ -6,8 +6,8 @@ SRC_URI = "\
    https://www.webkitgtk.org/releases/webkitgtk-${PV}.tar.xz \
 "
 
-SRC_URI[md5sum] = "3fdda40dc10eb2a00d5fba4219b83967"
-SRC_URI[sha256sum] = "dffe93a241f03f1c73b369f4e323e4d8f12e39d33d5515948cbf454ca4b526e2"
+SRC_URI[md5sum] = "efb69a0cc3cc67ef2647efec22e44c69"
+SRC_URI[sha256sum] = "579b307d78fa16a73f112790178022166d7ad17d4147492ced9b9fba48f20dd8"
 
 PACKAGECONFIG ?= " ${@bb.utils.contains('DISTRO_FEATURES', 'x11', 'x11', '', d)} \
                    ${@bb.utils.contains('DISTRO_FEATURES', 'wayland', 'wayland', '', d)} \


### PR DESCRIPTION
Latest stable released on 2018-06-11

Changes: https://www.webkitgtk.org/2018/06/11/webkitgtk2.20.3-released.html