### PR TITLE
Fixes for wpewebkit_2.21.91, new cog 0.1 and new WPEBackend-fdo (0.1~git0.2)

### DIFF
--- a/recipes-browser/cog/cog.inc
+++ b/recipes-browser/cog/cog.inc
@@ -1,0 +1,40 @@
+SUMMARY = "Cog is a small launcher designed for the WebKit WPE port. \
+           But it also allows to use the WebKit GTK port instead. \
+           Cog is small: provides no user interface, and is suitable \
+           to be used as a Web application container. Cog may be \
+           presented fullscreen depending on the WPE backend being used. \
+           "
+HOMEPAGE = "https://github.com/Igalia/cog"
+BUGTRACKER = "https://github.com/Igalia/cog/issues"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://COPYING;md5=bf1229cd7425b302d60cdb641b0ce5fb"
+
+# Depend on wpewebkit unless the webkitgtk packageconfig option is selected.
+DEPENDS = " \
+            ${@bb.utils.contains('PACKAGECONFIG', 'webkitgtk', 'webkitgtk', 'wpewebkit', d)} \
+            libsoup-2.4 glib-2.0 \
+            "
+
+# At run-time cog package should depend on virtual/wpebackend unless webkitgtk+ is enabled.
+RDEPENDS_${PN} += "${@bb.utils.contains('PACKAGECONFIG', 'webkitgtk', '', 'virtual/wpebackend', d)}"
+
+inherit cmake
+
+# Cog can work with any wpebackend.
+# But for using wpebackend-fdo this has to be enabled at build time.
+PREFERRED_PROVIDER_virtual/wpebackend ?= "wpebackend-fdo"
+PACKAGECONFIG ?= " ${@bb.utils.contains('PREFERRED_PROVIDER_virtual/wpebackend', 'wpebackend-fdo', 'fdo', '', d)} "
+
+# libcogplatform*.so are plugins that should go on the main package (not on -dev)
+# https://github.com/Igalia/cog/commit/758ed08555e8152a2becd2178d1f3a4ce6e67af9
+# Also libWPEBackend-default.so should go into the main package.
+FILES_SOLIBSDEV = "${libdir}/libcogcore*.so"
+FILES_${PN} += "${libdir}/libcogplatform*.so"
+INSANE_SKIP_${PN} = "dev-so"
+
+# Use WebKitGTK+ instead of WPEWebKit
+PACKAGECONFIG[webkitgtk] = "-DCOG_USE_WEBKITGTK=ON,-DCOG_USE_WEBKITGTK=OFF"
+# Expose remote control interface on system bus.
+PACKAGECONFIG[dbus] = "-DCOG_DBUS_SYSTEM_BUS=ON,-DCOG_DBUS_SYSTEM_BUS=OFF"
+# Use wpebackend-fdo.
+PACKAGECONFIG[fdo] = "-DCOG_PLATFORM_FDO=ON,-DCOG_PLATFORM_FDO=OFF,wpebackend-fdo"

--- a/recipes-browser/cog/cog_0.1.0.bb
+++ b/recipes-browser/cog/cog_0.1.0.bb
@@ -1,0 +1,6 @@
+require cog.inc
+
+SRC_URI = "https://github.com/Igalia/${PN}/archive/v${PV}.tar.gz"
+
+SRC_URI[md5sum] = "141b94b4cac9b70a9de3e1a2efc21019"
+SRC_URI[sha256sum] = "7cefb6e045eaeb02ddb152cf283c1f35221110d0370a0fba7b76d4e96391279c"

--- a/recipes-browser/cog/cog_git.bb
+++ b/recipes-browser/cog/cog_git.bb
@@ -1,7 +1,5 @@
 require cog.inc
 
-# Please: keep PV to the date of the last update, so the version number
-# is an always increasing number to avoid "version goes backwards" errors.
 PV = "git${AUTOREV}"
 SRCREV = "${AUTOREV}"
 SRC_URI = " git://github.com/Igalia/cog.git;protocol=https;branch=master"

--- a/recipes-browser/cog/cog_git.bb
+++ b/recipes-browser/cog/cog_git.bb
@@ -1,47 +1,8 @@
-SUMMARY = "Cog is a small launcher designed for the WebKit WPE port. \
-           But it also allows to use the WebKit GTK port instead. \
-           Cog is small: provides no user interface, and is suitable \
-           to be used as a Web application container. Cog may be \
-           presented fullscreen depending on the WPE backend being used. \
-           "
-HOMEPAGE = "https://github.com/Igalia/cog"
-BUGTRACKER = "https://github.com/Igalia/cog/issues"
-LICENSE = "MIT"
-LIC_FILES_CHKSUM = "file://COPYING;md5=bf1229cd7425b302d60cdb641b0ce5fb"
+require cog.inc
 
 # Please: keep PV to the date of the last update, so the version number
 # is an always increasing number to avoid "version goes backwards" errors.
-PV = "20180809"
+PV = "git${AUTOREV}"
 SRCREV = "${AUTOREV}"
 SRC_URI = " git://github.com/Igalia/cog.git;protocol=https;branch=master"
 S = "${WORKDIR}/git"
-
-# Depend on wpewebkit unless the webkitgtk packageconfig option is selected.
-DEPENDS = " \
-            ${@bb.utils.contains('PACKAGECONFIG', 'webkitgtk', 'webkitgtk', 'wpewebkit', d)} \
-            libsoup-2.4 glib-2.0 \
-            "
-
-# At run-time cog package should depend on virtual/wpebackend unless webkitgtk+ is enabled.
-RDEPENDS_${PN} += "${@bb.utils.contains('PACKAGECONFIG', 'webkitgtk', '', 'virtual/wpebackend', d)}"
-
-inherit cmake
-
-# Cog can work with any wpebackend.
-# But for using wpebackend-fdo this has to be enabled at build time.
-PREFERRED_PROVIDER_virtual/wpebackend ?= "wpebackend-fdo"
-PACKAGECONFIG ?= " ${@bb.utils.contains('PREFERRED_PROVIDER_virtual/wpebackend', 'wpebackend-fdo', 'fdo', '', d)} "
-
-# libcogplatform*.so are plugins that should go on the main package (not on -dev)
-# https://github.com/Igalia/cog/commit/758ed08555e8152a2becd2178d1f3a4ce6e67af9
-# Also libWPEBackend-default.so should go into the main package.
-FILES_SOLIBSDEV = "${libdir}/libcogcore*.so"
-FILES_${PN} += "${libdir}/libcogplatform*.so"
-INSANE_SKIP_${PN} = "dev-so"
-
-# Use WebKitGTK+ instead of WPEWebKit
-PACKAGECONFIG[webkitgtk] = "-DCOG_USE_WEBKITGTK=ON,-DCOG_USE_WEBKITGTK=OFF"
-# Expose remote control interface on system bus.
-PACKAGECONFIG[dbus] = "-DCOG_DBUS_SYSTEM_BUS=ON,-DCOG_DBUS_SYSTEM_BUS=OFF"
-# Use wpebackend-fdo.
-PACKAGECONFIG[fdo] = "-DCOG_PLATFORM_FDO=ON,-DCOG_PLATFORM_FDO=OFF,wpebackend-fdo"

--- a/recipes-browser/wpebackend-fdo/wpebackend-fdo_0.1~git0.2.bb
+++ b/recipes-browser/wpebackend-fdo/wpebackend-fdo_0.1~git0.2.bb
@@ -1,0 +1,16 @@
+require wpebackend-fdo.inc
+
+# https://github.com/Igalia/WPEBackend-fdo/pull/19
+
+# This version of WPEBackend-fdo is not selected by default on this layer,
+# as the released versions is preferred.
+# To select it, add on your local.conf conf file the line below:
+#
+# PREFERRED_VERSION_wpebackend-fdo = "0.1~git%"
+
+SRCREV = "da746af2dff6b972c5c4903a132edcafdb768926"
+SRC_URI = "git://github.com/Igalia/WPEBackend-fdo.git;protocol=https;branch=master"
+
+S = "${WORKDIR}/git"
+
+DEPENDS += " wpebackend"

--- a/recipes-browser/wpewebkit/wpewebkit/fix-189500.patch
+++ b/recipes-browser/wpewebkit/wpewebkit/fix-189500.patch
@@ -1,0 +1,60 @@
+Index: wpewebkit-2.21.91/Source/WebCore/page/Page.cpp
+===================================================================
+--- wpewebkit-2.21.91.orig/Source/WebCore/page/Page.cpp
++++ wpewebkit-2.21.91/Source/WebCore/page/Page.cpp
+@@ -242,7 +242,9 @@ Page::Page(PageConfiguration&& pageConfi
+     , m_userContentProvider(*WTFMove(pageConfiguration.userContentProvider))
+     , m_visitedLinkStore(*WTFMove(pageConfiguration.visitedLinkStore))
+     , m_sessionID(PAL::SessionID::defaultSessionID())
++#if ENABLE(VIDEO)
+     , m_playbackControlsManagerUpdateTimer(*this, &Page::playbackControlsManagerUpdateTimerFired)
++#endif
+     , m_isUtilityPage(isUtilityPageChromeClient(chrome().client()))
+     , m_performanceMonitor(isUtilityPage() ? nullptr : std::make_unique<PerformanceMonitor>(*this))
+     , m_lowPowerModeNotifier(std::make_unique<LowPowerModeNotifier>([this](bool isLowPowerModeEnabled) { handleLowModePowerChange(isLowPowerModeEnabled); }))
+@@ -1511,10 +1513,13 @@ void Page::updateIsPlayingMedia(uint64_t
+ 
+ void Page::schedulePlaybackControlsManagerUpdate()
+ {
++#if ENABLE(VIDEO)
+     if (!m_playbackControlsManagerUpdateTimer.isActive())
+         m_playbackControlsManagerUpdateTimer.startOneShot(0_s);
++#endif
+ }
+ 
++#if ENABLE(VIDEO)
+ void Page::playbackControlsManagerUpdateTimerFired()
+ {
+     if (auto bestMediaElement = HTMLMediaElement::bestMediaElementForShowingPlaybackControlsManager(MediaElementSession::PlaybackControlsPurpose::ControlsManager))
+@@ -1522,6 +1527,7 @@ void Page::playbackControlsManagerUpdate
+     else
+         chrome().client().clearPlaybackControlsManager();
+ }
++#endif
+ 
+ void Page::setMuted(MediaProducer::MutedStateFlags muted)
+ {
+Index: wpewebkit-2.21.91/Source/WebCore/page/Page.h
+===================================================================
+--- wpewebkit-2.21.91.orig/Source/WebCore/page/Page.h
++++ wpewebkit-2.21.91/Source/WebCore/page/Page.h
+@@ -689,7 +689,9 @@ private:
+ 
+     std::optional<std::pair<MediaCanStartListener&, Document&>> takeAnyMediaCanStartListener();
+ 
++#if ENABLE(VIDEO)
+     void playbackControlsManagerUpdateTimerFired();
++#endif
+ 
+     Vector<Ref<PluginViewBase>> pluginViews();
+ 
+@@ -868,7 +870,9 @@ private:
+ 
+     MediaProducer::MediaStateFlags m_mediaState { MediaProducer::IsNotPlaying };
+ 
++#if ENABLE(VIDEO)
+     Timer m_playbackControlsManagerUpdateTimer;
++#endif
+ 
+     bool m_allowsMediaDocumentInlinePlayback { false };
+     bool m_allowsPlaybackControlsForAutoplayingAudio { false };

--- a/recipes-browser/wpewebkit/wpewebkit/fix-189506.patch
+++ b/recipes-browser/wpewebkit/wpewebkit/fix-189506.patch
@@ -1,0 +1,20 @@
+Index: wpewebkit-2.21.91/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp
+===================================================================
+--- wpewebkit-2.21.91.orig/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp
++++ wpewebkit-2.21.91/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp
+@@ -100,6 +100,7 @@ void WebFullScreenManager::videoControls
+ 
+ void WebFullScreenManager::setPIPStandbyElement(WebCore::HTMLVideoElement* pipStandbyElement)
+ {
++#if ENABLE(VIDEO)
+     if (pipStandbyElement == m_pipStandbyElement)
+         return;
+ 
+@@ -110,6 +111,7 @@ void WebFullScreenManager::setPIPStandby
+ 
+     if (m_pipStandbyElement)
+         m_pipStandbyElement->setVideoFullscreenStandby(true);
++#endif
+ }
+ 
+ void WebFullScreenManager::didReceiveMessage(IPC::Connection& connection, IPC::Decoder& decoder)

--- a/recipes-browser/wpewebkit/wpewebkit/fix-189540.patch
+++ b/recipes-browser/wpewebkit/wpewebkit/fix-189540.patch
@@ -1,0 +1,38 @@
+Index: wpewebkit-2.21.91/Source/WebCore/platform/GStreamer.cmake
+===================================================================
+--- wpewebkit-2.21.91.orig/Source/WebCore/platform/GStreamer.cmake
++++ wpewebkit-2.21.91/Source/WebCore/platform/GStreamer.cmake
+@@ -36,7 +36,6 @@ if (ENABLE_VIDEO OR ENABLE_WEB_AUDIO)
+         platform/mediastream/libwebrtc/GStreamerVideoDecoderFactory.cpp
+         platform/mediastream/libwebrtc/GStreamerVideoEncoderFactory.cpp
+         platform/mediastream/libwebrtc/LibWebRTCAudioModule.cpp
+-        platform/mediastream/libwebrtc/LibWebRTCProviderGlib.cpp
+ 
+         platform/mediastream/gstreamer/GStreamerAudioCaptureSource.cpp
+         platform/mediastream/gstreamer/GStreamerAudioCapturer.cpp
+Index: wpewebkit-2.21.91/Source/WebCore/platform/SourcesGLib.txt
+===================================================================
+--- wpewebkit-2.21.91.orig/Source/WebCore/platform/SourcesGLib.txt
++++ wpewebkit-2.21.91/Source/WebCore/platform/SourcesGLib.txt
+@@ -35,3 +35,5 @@ platform/glib/SharedBufferGlib.cpp
+ platform/glib/UserAgentGLib.cpp
+ 
+ platform/network/glib/NetworkStateNotifierGLib.cpp
++
++platform/mediastream/libwebrtc/LibWebRTCProviderGlib.cpp
+Index: wpewebkit-2.21.91/Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCProviderGlib.cpp
+===================================================================
+--- wpewebkit-2.21.91.orig/Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCProviderGlib.cpp
++++ wpewebkit-2.21.91/Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCProviderGlib.cpp
+@@ -41,7 +41,11 @@ UniqueRef<LibWebRTCProvider> LibWebRTCPr
+ 
+ bool LibWebRTCProvider::webRTCAvailable()
+ {
++#if USE(LIBWEBRTC) && USE(GSTREAMER)
+     return true;
++#else
++    return false;
++#endif
+ }
+ 
+ #if USE(LIBWEBRTC) && USE(GSTREAMER)

--- a/recipes-browser/wpewebkit/wpewebkit_2.21.91.bb
+++ b/recipes-browser/wpewebkit/wpewebkit_2.21.91.bb
@@ -2,7 +2,10 @@ require wpewebkit.inc
 
 FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 SRC_URI = "https://wpewebkit.org/releases/${PN}-${PV}.tar.xz \
-           file://0001-REGRESSION-r217927-WPE-2.22-GSTREAMER_GL-Video-appea.patch"
+           file://0001-REGRESSION-r217927-WPE-2.22-GSTREAMER_GL-Video-appea.patch \
+           file://fix-189500.patch \
+           file://fix-189506.patch \
+           file://fix-189540.patch"
 
 SRC_URI[md5sum] = "08778a95eba2de141d8aaff3d802c811"
 SRC_URI[sha256sum] = "e75b1ca225fa9303017e954b6203e4f1750a7566fa852443e6fd574fd5f926b8"


### PR DESCRIPTION
* Create recipe for cog_0.1 compatible
* Add upstreamed patches for wpewebkit_2.21.91 needed to build package
* Add support for building on older versions of wayland and EGL in WPEBackend-fdo (0.1~git0.2)