### PR TITLE
Set FILES_SOLIBSDEV="" in wpebackend-fdo

### DIFF
--- a/recipes-browser/wpebackend-fdo/wpebackend-fdo.inc
+++ b/recipes-browser/wpebackend-fdo/wpebackend-fdo.inc
@@ -9,3 +9,7 @@ PROVIDES += "virtual/wpebackend"
 RPROVIDES_${PN} += "virtual/wpebackend"
 
 inherit cmake
+
+FILES_SOLIBSDEV = ""
+FILES_${PN} += "${libdir}/libWPEBackend-fdo-0.1.so"
+INSANE_SKIP_${PN} ="dev-so"


### PR DESCRIPTION
FILES_SOLIBSDEV="" forces all libraries (versioned and unversioned)
to be included in the wpebackend-fdo package.

Related with: https://github.com/Igalia/meta-webkit/pull/27#discussion_r216009124