### PR TITLE
wpebackend-fdo_git.bb: set PV to 1.0.0~git

### DIFF
--- a/recipes-browser/wpebackend-fdo/wpebackend-fdo_git.bb
+++ b/recipes-browser/wpebackend-fdo/wpebackend-fdo_git.bb
@@ -1,13 +1,13 @@
 require wpebackend-fdo.inc
 
 DEFAULT_PRERENCE = "-1"
-PV = "1.0~git"
+PV = "1.0.0~git"
 
 # This version of WPEBackend-fdo is not selected by default on this layer,
 # as the released versions is preferred.
 # To select it, add on your local.conf conf file the line below:
 #
-# PREFERRED_VERSION_wpebackend-fdo = "1.0~git%"
+# PREFERRED_VERSION_wpebackend-fdo = "1.0.0~git%"
 
 SRCREV = "${AUTOREV}"
 SRC_URI = "git://github.com/Igalia/WPEBackend-fdo.git;protocol=https;branch=master"


### PR DESCRIPTION
Signed-off-by: Maciej Pijanowski <maciej.pijanowski@3mdeb.com>

When trying to build wpebackend-fdo from git with the recent WPEwebkit (2.22.0),
the build fails at `package wpewebkit-2.22.0-r0.armv7vet2hf_neon conflicts with wpebackend-fdo < 1.0 provided by libwpebackend-fdo-0.1-1-1.0~git-r0.armv7vehf_neon`

Apparently, the build systems consider the version `1.0~git` to be lower that `1.0`. Changing
it to `1.0.0~git` allows the build to pass.