### PR TITLE
fix: wpebackend-fdo 0.1 version still needs libWPEBackend-default symlink

### DIFF
--- a/recipes-browser/wpebackend-fdo/wpebackend-fdo_0.1.bb
+++ b/recipes-browser/wpebackend-fdo/wpebackend-fdo_0.1.bb
@@ -7,3 +7,10 @@ SRC_URI[sha256sum] = "76a95cb7b597618600ac8d69147adf7dd922121acab2725f6ed99ca5b7
 S = "${WORKDIR}/${PN}-${PV}"
 
 DEPENDS += " wpebackend"
+
+FILES_${PN} += " ${libdir}/libWPEBackend-default.so"
+
+do_install_append () {
+    install -d "${D}/usr/lib"
+    ln -s libWPEBackend-fdo-0.1.so "${D}/usr/lib/libWPEBackend-default.so"
+}

--- a/recipes-browser/wpebackend-fdo/wpebackend-fdo_0.1~git0.2.bb
+++ b/recipes-browser/wpebackend-fdo/wpebackend-fdo_0.1~git0.2.bb
@@ -14,3 +14,10 @@ SRC_URI = "git://github.com/Igalia/WPEBackend-fdo.git;protocol=https;branch=mast
 S = "${WORKDIR}/git"
 
 DEPENDS += " wpebackend"
+
+FILES_${PN} += " ${libdir}/libWPEBackend-default.so"
+
+do_install_append () {
+    install -d "${D}/usr/lib"
+    ln -s libWPEBackend-fdo-0.1.so "${D}/usr/lib/libWPEBackend-default.so"
+}


### PR DESCRIPTION
* wpebackend-fdo 0.1 version is used by wpewebkit 2.20 version.
* Note: This is will not the case of the libwpe package. Since WPE 2.22.x,
  it won't be needed anymore (https://github.com/Igalia/cog/pull/60),
  it is recommended to set the implementation library name using the
  libwpe API like this instead of having the ugly symlink.