### PR TITLE
cog: Patch to make it possible to build 0.1 against GLib >=2.58

### DIFF
--- a/recipes-browser/cog/cog/0001-Make-it-possible-to-build-against-GLib-2.58-and-newe.patch
+++ b/recipes-browser/cog/cog/0001-Make-it-possible-to-build-against-GLib-2.58-and-newe.patch
@@ -1,0 +1,28 @@
+From 063df115456a24e464d1e6f284df22a0e65aea8e Mon Sep 17 00:00:00 2001
+From: Adrian Perez de Castro <aperez@igalia.com>
+Date: Thu, 13 Sep 2018 23:48:01 +0300
+Subject: [PATCH] Make it possible to build against GLib 2.58 and newer
+
+Starting from 2.58.0 GLib already includes the definition needed
+to use g_autoptr(GEnumClass).
+---
+ core/cog-utils.h | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/core/cog-utils.h b/core/cog-utils.h
+index 81eb4dc..1abada2 100644
+--- a/core/cog-utils.h
++++ b/core/cog-utils.h
+@@ -17,7 +17,9 @@ G_BEGIN_DECLS
+ 
+ typedef struct _GObjectClass GObjectClass;
+ 
++#if !GLIB_CHECK_VERSION(2, 58, 0)
+ G_DEFINE_AUTOPTR_CLEANUP_FUNC (GEnumClass, g_type_class_unref)
++#endif // !GLIB_CHECK_VERSION
+ 
+ 
+ char* cog_appid_to_dbus_object_path (const char *appid)
+-- 
+2.17.1
+

--- a/recipes-browser/cog/cog_0.1.0.bb
+++ b/recipes-browser/cog/cog_0.1.0.bb
@@ -1,6 +1,8 @@
 require cog.inc
 
-SRC_URI = "https://github.com/Igalia/${PN}/archive/v${PV}.tar.gz"
+SRC_URI = "https://github.com/Igalia/${PN}/archive/v${PV}.tar.gz \
+           file://0001-Make-it-possible-to-build-against-GLib-2.58-and-newe.patch \
+          "
 
 SRC_URI[md5sum] = "141b94b4cac9b70a9de3e1a2efc21019"
 SRC_URI[sha256sum] = "7cefb6e045eaeb02ddb152cf283c1f35221110d0370a0fba7b76d4e96391279c"


### PR DESCRIPTION
This patch is needed to compile cog0.1 in Thud.

Starting from 2.58.0 GLib already includes the definition needed
to use g_autoptr(GEnumClass).

Original patch extracted from `cog` (`master`): https://github.com/Igalia/cog/commit/063df115456a24e464d1e6f284df22a0e65aea8e

A	recipes-browser/cog/cog/0001-Make-it-possible-to-build-against-GLib-2.58-and-newe.patch
M	recipes-browser/cog/cog_0.1.0.bb

Alread tested in `meta-perf-browser`: https://gitlab.com/saavedra.pablo/meta-perf-browser/-/jobs/128387177