### PR TITLE
Various changes in the recipes 

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,76 @@
+thud-wandboard-mesa-weston-wpe-2.20:
+  tags:
+    - meta-webkit
+  script:
+    - mkdir -p ~/yocto-wandboard-wpe
+    - cd ~/yocto-wandboard-wpe
+    - repo init -u https://gitlab.com/saavedra.pablo/meta-perf-browser.git -m manifest.xml -b nightly
+    - repo sync --force-sync
+    - pushd sources/meta-webkit
+    - git checkout $CI_COMMIT_SHA
+    - popd
+    - source setup-environment wandboard-mesa-wpe-2.20 --update-config
+    - rm -rf tmp
+    - bitbake core-image-weston-wpe
+
+thud-wandboard-mesa-weston-wpe-2.22:
+  tags:
+    - meta-webkit
+  script:
+    - mkdir -p ~/yocto-wandboard-wpe
+    - cd ~/yocto-wandboard-wpe
+    - repo init -u https://gitlab.com/saavedra.pablo/meta-perf-browser.git -m manifest.xml -b nightly
+    - repo sync --force-sync
+    - pushd sources/meta-webkit
+    - git checkout $CI_COMMIT_SHA
+    - popd
+    - source setup-environment wandboard-mesa-wpe-2.22 --update-config
+    - rm -rf tmp
+    - bitbake core-image-weston-wpe
+
+thud-wandboard-mesa-weston-wpe-trunk:
+  allow_failure: true
+  tags:
+    - meta-webkit
+  script:
+    - mkdir -p ~/yocto-wandboard-wpe
+    - cd ~/yocto-wandboard-wpe
+    - repo init -u https://gitlab.com/saavedra.pablo/meta-perf-browser.git -m manifest.xml -b nightly
+    - repo sync --force-sync
+    - pushd sources/meta-webkit
+    - git checkout $CI_COMMIT_SHA
+    - popd
+    - source setup-environment wandboard-mesa-wpe-trunk --update-config
+    - rm -rf tmp
+    - bitbake core-image-weston-wpe
+
+thud-wandboard-mesa-weston-wpe-qt:
+  allow_failure: true
+  tags:
+    - meta-webkit
+  script:
+    - mkdir -p ~/yocto-wandboard-wpe
+    - cd ~/yocto-wandboard-wpe
+    - repo init -u https://gitlab.com/saavedra.pablo/meta-perf-browser.git -m manifest.xml -b nightly
+    - repo sync --force-sync
+    - pushd sources/meta-webkit
+    - git checkout $CI_COMMIT_SHA
+    - popd
+    - source setup-environment wandboard-mesa-wpe-qt --update-config
+    - rm -rf tmp
+    - bitbake core-image-weston-wpe
+
+thud-rpi3-vc4graphics-wpe-2.22:
+  tags:
+    - meta-webkit
+  script:
+    - mkdir -p ~/yocto-vc4graphics-wpe
+    - cd ~/yocto-vc4graphics-wpe
+    - repo init -u https://gitlab.com/saavedra.pablo/meta-perf-browser.git -m manifest.xml -b nightly
+    - repo sync --force-sync
+    - pushd sources/meta-webkit
+    - git checkout $CI_COMMIT_SHA
+    - popd
+    - source setup-environment rpi3-vc4graphics-wpe-2.22 --update-config
+    - rm -rf tmp
+    - bitbake core-image-wpe

--- a/recipes-browser/cog/cog_0.1.1.bb
+++ b/recipes-browser/cog/cog_0.1.1.bb
@@ -4,3 +4,5 @@ SRC_URI = "https://github.com/Igalia/${PN}/archive/v${PV}.tar.gz"
 
 SRC_URI[md5sum] = "b2d4fe2fef6ab10a920ab8ee034c2682"
 SRC_URI[sha256sum] = "86e760c8dcd021fbc4d7faacf81b90fcd4d8a40e43261be1fbdad0e674f580b6"
+
+RCONFLICTS_${PN} = "wpewebkit (>= 2.21)"

--- a/recipes-browser/cog/cog_0.2.0.bb
+++ b/recipes-browser/cog/cog_0.2.0.bb
@@ -1,0 +1,8 @@
+require cog.inc
+
+SRC_URI = "https://github.com/Igalia/${PN}/archive/v${PV}.tar.gz"
+
+SRC_URI[md5sum] = "2fcb68ae8d52bb4212f9e24724b83f33"
+SRC_URI[sha256sum] = "206302966c6019260f5a7a20b4c6afbd4ce77530f7b9cd638fafeed07e47cada"
+
+RCONFLICTS_${PN} = "wpewebkit (>= 2.23)"

--- a/recipes-browser/libwpe/libwpe.inc
+++ b/recipes-browser/libwpe/libwpe.inc
@@ -6,6 +6,9 @@ LICENSE = "BSD"
 LIC_FILES_CHKSUM = "file://COPYING;md5=6ae4db0d4b812334e1539cd5aa6e2f46"
 DEPENDS = "virtual/egl libxkbcommon"
 
+PROVIDES += "virtual/libwpe"
+RPROVIDES_${PN} += "virtual/libwpe"
+
 # Workaround build issue with RPi userland EGL libraries.
 CFLAGS_append_rpi = " ${@bb.utils.contains('MACHINE_FEATURES', 'vc4graphics', '', '-D_GNU_SOURCE', d)}"
 

--- a/recipes-browser/wpebackend-rdk/wpebackend-rdk.inc
+++ b/recipes-browser/wpebackend-rdk/wpebackend-rdk.inc
@@ -1,0 +1,37 @@
+SUMMARY = "Backend for WPE with specific support for embedded devices used on the RDK"
+HOMEPAGE = "https://github.com/WebPlatformForEmbedded/WPEBackend-rdk"
+BUGTRACKER = "https://github.com/WebPlatformForEmbedded/WPEBackend-rdk/issues"
+
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://src/wayland/display.h;;beginline=5;endline=24;md5=b1c8cb6b0857048a21b33611f01c575a"
+
+PROVIDES += "virtual/wpebackend"
+RPROVIDES_${PN} += "virtual/wpebackend"
+
+inherit cmake pkgconfig
+
+
+PACKAGECONFIG ?= "wayland"
+
+# device specific backends
+PACKAGECONFIG[intelce] = "-DUSE_BACKEND_INTEL_CE=ON -DUSE_KEY_INPUT_HANDLING_LINUX_INPUT=ON,,intelce-display"
+PACKAGECONFIG[nexus] = "-DUSE_BACKEND_BCM_NEXUS=ON -DUSE_KEY_INPUT_HANDLING_LINUX_INPUT=ON,,broadcom-refsw"
+PACKAGECONFIG[rpi] = "-DUSE_BACKEND_BCM_RPI=ON -DUSE_KEY_INPUT_HANDLING_LINUX_INPUT=ON,,userland"
+PACKAGECONFIG[stm] = "-DUSE_BACKEND_STM=ON -DUSE_KEY_INPUT_HANDLING_LINUX_INPUT=OFF,,libxkbcommon"
+PACKAGECONFIG[imx6] =  "-DUSE_BACKEND_VIV_IMX6_EGL=ON -DUSE_KEY_INPUT_HANDLING_LINUX_INPUT=ON,,imx-gpu-viv"
+
+# Wayland selectors
+PACKAGECONFIG[wayland] = "-DUSE_BACKEND_WAYLAND_EGL=ON -DUSE_KEY_INPUT_HANDLING_LINUX_INPUT=OFF,,wayland libxkbcommon"
+PACKAGECONFIG[realtek] = "-DUSE_BACKEND_REALTEK=ON -DUSE_KEY_INPUT_HANDLING_LINUX_INPUT=OFF,,wayland libxkbcommon"
+PACKAGECONFIG[westeros] = "-DUSE_BACKEND_WESTEROS=ON -DUSE_BACKEND_BCM_RPI=OFF -DUSE_KEY_INPUT_HANDLING_LINUX_INPUT=OFF -DUSE_WESTEROS_SINK=ON,,wayland westeros libxkbcommon"
+PACKAGECONFIG[bcm-weston] = "-DUSE_BACKEND_BCM_NEXUS_WAYLAND=ON,-DUSE_BACKEND_BCM_NEXUS_WAYLAND=OFF,,"
+PACKAGECONFIG[westeros-mesa] = "-DUSE_BACKEND_WESTEROS_MESA=ON,,"
+
+do_install() {
+	install -d ${D}${libdir}
+	install -m 0755 ${B}/libWPEBackend-*.so ${D}${libdir}/
+}
+
+FILES_SOLIBSDEV = ""
+FILES_${PN} += "${libdir}/libWPEBackend-default.so ${libdir}/libWPEBackend-rdk.so"
+INSANE_SKIP ="dev-so"

--- a/recipes-browser/wpebackend-rdk/wpebackend-rdk/0001-Fix-include-of-headers-after-WPEBackend-commit-2bf3c.patch
+++ b/recipes-browser/wpebackend-rdk/wpebackend-rdk/0001-Fix-include-of-headers-after-WPEBackend-commit-2bf3c.patch
@@ -1,0 +1,633 @@
+From 4f1ff2cb0f249913a1ba7cd2d3c7fa832609c553 Mon Sep 17 00:00:00 2001
+From: Carlos Alberto Lopez Perez <clopez@igalia.com>
+Date: Mon, 14 May 2018 15:02:20 +0200
+Subject: [PATCH] Fix include of headers after WPEBackend commit 2bf3c3ae
+
+* wpe/wpe.h should be included instead of wpe/input.h, wpe/loader.h,
+  wpe/pasteboard.h, wpe/renderer-host.h and wpe/view-backend.h
+
+* wpe/wpe-egl.h should be included instead of wpe/renderer-backend-egl.h
+---
+ cmake/FindWPE.cmake                         | 2 +-
+ src/bcm-nexus-wayland/interfaces.h          | 4 ++--
+ src/bcm-nexus-wayland/renderer-backend.cpp  | 2 +-
+ src/bcm-nexus-wayland/view-backend.cpp      | 2 +-
+ src/bcm-nexus/interfaces.h                  | 4 ++--
+ src/bcm-nexus/renderer-backend.cpp          | 2 +-
+ src/bcm-nexus/view-backend.cpp              | 2 +-
+ src/bcm-rpi/interfaces.h                    | 4 ++--
+ src/bcm-rpi/renderer-backend.cpp            | 2 +-
+ src/bcm-rpi/view-backend.cpp                | 2 +-
+ src/input/KeyboardEventHandler.h            | 2 +-
+ src/input/Libinput/KeyboardEventRepeating.h | 2 +-
+ src/input/Libinput/LibinputServer.cpp       | 2 +-
+ src/input/Libinput/LibinputServer.h         | 2 +-
+ src/input/LinuxInput/input-linuxinput.h     | 2 +-
+ src/input/XKB/input-libxkbcommon.h          | 2 +-
+ src/intelce/interfaces.h                    | 4 ++--
+ src/intelce/renderer-backend.cpp            | 2 +-
+ src/intelce/view-backend.cpp                | 2 +-
+ src/loader-impl.cpp                         | 4 ++--
+ src/realtek-wl-egl/interfaces.h             | 4 ++--
+ src/realtek-wl-egl/renderer-backend.cpp     | 2 +-
+ src/realtek-wl-egl/view-backend.cpp         | 3 +--
+ src/viv-imx6/interfaces.h                   | 4 ++--
+ src/viv-imx6/renderer-backend.cpp           | 2 +-
+ src/viv-imx6/view-backend.cpp               | 2 +-
+ src/wayland-egl/interfaces.h                | 4 ++--
+ src/wayland-egl/renderer-backend.cpp        | 2 +-
+ src/wayland-egl/view-backend.cpp            | 3 +--
+ src/wayland/display.cpp                     | 3 +--
+ src/wayland/display.h                       | 2 +-
+ src/westeros/WesterosViewbackendInput.cpp   | 3 +--
+ src/westeros/WesterosViewbackendOutput.cpp  | 2 +-
+ src/westeros/interfaces.h                   | 4 ++--
+ src/westeros/renderer-backend.cpp           | 2 +-
+ src/westeros/view-backend.cpp               | 2 +-
+ src/wpeframework/display.cpp                | 3 +--
+ src/wpeframework/display.h                  | 2 +-
+ src/wpeframework/interfaces.h               | 4 ++--
+ src/wpeframework/renderer-backend.cpp       | 2 +-
+ src/wpeframework/view-backend.cpp           | 3 +--
+ src/wpeframework/view-backend.old.cpp       | 3 +--
+ 42 files changed, 52 insertions(+), 59 deletions(-)
+
+diff --git a/cmake/FindWPE.cmake b/cmake/FindWPE.cmake
+index fb050ce..b71b17e 100644
+--- a/cmake/FindWPE.cmake
++++ b/cmake/FindWPE.cmake
+@@ -32,7 +32,7 @@ find_package(PkgConfig)
+ pkg_check_modules(PC_WPE QUIET wpe-0.1)
+ 
+ find_path(WPE_INCLUDE_DIRS
+-    NAMES wpe/loader.h
++    NAMES wpe/wpe.h
+     HINTS ${PC_WPE_INCLUDEDIR} ${PC_WPE_INCLUDE_DIRS}
+ )
+ 
+diff --git a/src/bcm-nexus-wayland/interfaces.h b/src/bcm-nexus-wayland/interfaces.h
+index db2006e..7a20fe0 100644
+--- a/src/bcm-nexus-wayland/interfaces.h
++++ b/src/bcm-nexus-wayland/interfaces.h
+@@ -1,8 +1,8 @@
+ #ifndef bcm_nexus_wayland_interfaces_h
+ #define bcm_nexus_wayland_interfaces_h
+ 
+-#include <wpe/renderer-backend-egl.h>
+-#include <wpe/view-backend.h>
++#include <wpe/wpe-egl.h>
++#include <wpe/wpe.h>
+ 
+ #ifdef __cplusplus
+ extern "C" {
+diff --git a/src/bcm-nexus-wayland/renderer-backend.cpp b/src/bcm-nexus-wayland/renderer-backend.cpp
+index d08bd4a..39f4c0f 100644
+--- a/src/bcm-nexus-wayland/renderer-backend.cpp
++++ b/src/bcm-nexus-wayland/renderer-backend.cpp
+@@ -25,7 +25,7 @@
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  */
+ 
+-#include <wpe/renderer-backend-egl.h>
++#include <wpe/wpe-egl.h>
+ 
+ #include "ipc.h"
+ #include "ipc-bcmnexuswl.h"
+diff --git a/src/bcm-nexus-wayland/view-backend.cpp b/src/bcm-nexus-wayland/view-backend.cpp
+index 8026ba8..af70476 100644
+--- a/src/bcm-nexus-wayland/view-backend.cpp
++++ b/src/bcm-nexus-wayland/view-backend.cpp
+@@ -25,7 +25,7 @@
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  */
+ 
+-#include <wpe/view-backend.h>
++#include <wpe/wpe.h>
+ 
+ #include "display.h"
+ #include "ipc.h"
+diff --git a/src/bcm-nexus/interfaces.h b/src/bcm-nexus/interfaces.h
+index 6075801..1f75fb2 100644
+--- a/src/bcm-nexus/interfaces.h
++++ b/src/bcm-nexus/interfaces.h
+@@ -28,8 +28,8 @@
+ #ifndef bcm_nexus_interfaces_h
+ #define bcm_nexus_interfaces_h
+ 
+-#include <wpe/renderer-backend-egl.h>
+-#include <wpe/view-backend.h>
++#include <wpe/wpe-egl.h>
++#include <wpe/wpe.h>
+ 
+ #ifdef __cplusplus
+ extern "C" {
+diff --git a/src/bcm-nexus/renderer-backend.cpp b/src/bcm-nexus/renderer-backend.cpp
+index 340d815..77a8635 100644
+--- a/src/bcm-nexus/renderer-backend.cpp
++++ b/src/bcm-nexus/renderer-backend.cpp
+@@ -25,7 +25,7 @@
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  */
+ 
+-#include <wpe/renderer-backend-egl.h>
++#include <wpe/wpe-egl.h>
+ 
+ #include "ipc.h"
+ #include "ipc-bcmnexus.h"
+diff --git a/src/bcm-nexus/view-backend.cpp b/src/bcm-nexus/view-backend.cpp
+index 2b6aee9..9f77c6f 100644
+--- a/src/bcm-nexus/view-backend.cpp
++++ b/src/bcm-nexus/view-backend.cpp
+@@ -25,7 +25,7 @@
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  */
+ 
+-#include <wpe/view-backend.h>
++#include <wpe/wpe.h>
+ 
+ #ifdef KEY_INPUT_HANDLING_LIBINPUT
+ #include "Libinput/LibinputServer.h"
+diff --git a/src/bcm-rpi/interfaces.h b/src/bcm-rpi/interfaces.h
+index 18a6bd4..fc7cfd6 100644
+--- a/src/bcm-rpi/interfaces.h
++++ b/src/bcm-rpi/interfaces.h
+@@ -30,8 +30,8 @@
+ 
+ #define __GBM__
+ 
+-#include <wpe/renderer-backend-egl.h>
+-#include <wpe/view-backend.h>
++#include <wpe/wpe-egl.h>
++#include <wpe/wpe.h>
+ 
+ #ifdef __cplusplus
+ extern "C" {
+diff --git a/src/bcm-rpi/renderer-backend.cpp b/src/bcm-rpi/renderer-backend.cpp
+index 2b3b495..fcdec97 100644
+--- a/src/bcm-rpi/renderer-backend.cpp
++++ b/src/bcm-rpi/renderer-backend.cpp
+@@ -25,7 +25,7 @@
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  */
+ 
+-#include <wpe/renderer-backend-egl.h>
++#include <wpe/wpe-egl.h>
+ 
+ #include "ipc.h"
+ #include "ipc-rpi.h"
+diff --git a/src/bcm-rpi/view-backend.cpp b/src/bcm-rpi/view-backend.cpp
+index d4ff2d5..3a96ad3 100644
+--- a/src/bcm-rpi/view-backend.cpp
++++ b/src/bcm-rpi/view-backend.cpp
+@@ -25,7 +25,7 @@
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  */
+ 
+-#include <wpe/view-backend.h>
++#include <wpe/wpe.h>
+ 
+ #include "Libinput/LibinputServer.h"
+ #include "cursor-data.h"
+diff --git a/src/input/KeyboardEventHandler.h b/src/input/KeyboardEventHandler.h
+index 937c4e2..c0cd66e 100644
+--- a/src/input/KeyboardEventHandler.h
++++ b/src/input/KeyboardEventHandler.h
+@@ -30,7 +30,7 @@
+ 
+ #include <memory>
+ #include <tuple>
+-#include <wpe/input.h>
++#include <wpe/wpe.h>
+ 
+ namespace WPE {
+ 
+diff --git a/src/input/Libinput/KeyboardEventRepeating.h b/src/input/Libinput/KeyboardEventRepeating.h
+index d631f45..b84c03f 100644
+--- a/src/input/Libinput/KeyboardEventRepeating.h
++++ b/src/input/Libinput/KeyboardEventRepeating.h
+@@ -29,7 +29,7 @@
+ #define WPE_Input_KeyboardEventRepeating_h
+ 
+ #include <glib.h>
+-#include <wpe/input.h>
++#include <wpe/wpe.h>
+ 
+ namespace WPE {
+ 
+diff --git a/src/input/Libinput/LibinputServer.cpp b/src/input/Libinput/LibinputServer.cpp
+index bb87a78..b18de55 100644
+--- a/src/input/Libinput/LibinputServer.cpp
++++ b/src/input/Libinput/LibinputServer.cpp
+@@ -32,7 +32,7 @@
+ #include <cstdio>
+ #include <fcntl.h>
+ #include <unistd.h>
+-#include <wpe/view-backend.h>
++#include <wpe/wpe.h>
+ 
+ namespace WPE {
+ 
+diff --git a/src/input/Libinput/LibinputServer.h b/src/input/Libinput/LibinputServer.h
+index 9734caa..b10021a 100644
+--- a/src/input/Libinput/LibinputServer.h
++++ b/src/input/Libinput/LibinputServer.h
+@@ -31,7 +31,7 @@
+ #include "KeyboardEventRepeating.h"
+ #include <glib.h>
+ #include <memory>
+-#include <wpe/input.h>
++#include <wpe/wpe.h>
+ #ifndef KEY_INPUT_HANDLING_VIRTUAL
+ #include <libudev.h>
+ #include <libinput.h>
+diff --git a/src/input/LinuxInput/input-linuxinput.h b/src/input/LinuxInput/input-linuxinput.h
+index e3caa8f..827f380 100644
+--- a/src/input/LinuxInput/input-linuxinput.h
++++ b/src/input/LinuxInput/input-linuxinput.h
+@@ -30,7 +30,7 @@
+ 
+ #ifdef KEY_INPUT_HANDLING_LINUX_INPUT
+ 
+-#include <wpe/input.h>
++#include <wpe/wpe.h>
+ 
+ #ifdef __cplusplus
+ extern "C" {
+diff --git a/src/input/XKB/input-libxkbcommon.h b/src/input/XKB/input-libxkbcommon.h
+index 035e7a0..032e4c0 100644
+--- a/src/input/XKB/input-libxkbcommon.h
++++ b/src/input/XKB/input-libxkbcommon.h
+@@ -30,7 +30,7 @@
+ 
+ #ifdef KEY_INPUT_HANDLING_XKB
+ 
+-#include <wpe/input.h>
++#include <wpe/wpe.h>
+ 
+ #ifdef __cplusplus
+ extern "C" {
+diff --git a/src/intelce/interfaces.h b/src/intelce/interfaces.h
+index 56d2739..f01334c 100644
+--- a/src/intelce/interfaces.h
++++ b/src/intelce/interfaces.h
+@@ -28,8 +28,8 @@
+ #ifndef intelce_interfaces_h
+ #define intelce_interfaces_h
+ 
+-#include <wpe/renderer-backend-egl.h>
+-#include <wpe/view-backend.h>
++#include <wpe/wpe-egl.h>
++#include <wpe/wpe.h>
+ 
+ #ifdef __cplusplus
+ extern "C" {
+diff --git a/src/intelce/renderer-backend.cpp b/src/intelce/renderer-backend.cpp
+index ec4644c..1056743 100644
+--- a/src/intelce/renderer-backend.cpp
++++ b/src/intelce/renderer-backend.cpp
+@@ -25,7 +25,7 @@
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  */
+ 
+-#include <wpe/renderer-backend-egl.h>
++#include <wpe/wpe-egl.h>
+ 
+ #include "ipc.h"
+ #include "ipc-intelce.h"
+diff --git a/src/intelce/view-backend.cpp b/src/intelce/view-backend.cpp
+index a91c42e..ac488d9 100644
+--- a/src/intelce/view-backend.cpp
++++ b/src/intelce/view-backend.cpp
+@@ -25,7 +25,7 @@
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  */
+ 
+-#include <wpe/view-backend.h>
++#include <wpe/wpe.h>
+ 
+ #include "Libinput/LibinputServer.h"
+ #include "ipc.h"
+diff --git a/src/loader-impl.cpp b/src/loader-impl.cpp
+index 72703dd..aaa8f4d 100644
+--- a/src/loader-impl.cpp
++++ b/src/loader-impl.cpp
+@@ -25,11 +25,11 @@
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  */
+ 
+-#include <wpe/loader.h>
++#include <wpe/wpe.h>
+ 
+ #include <cstdio>
+ #include <cstring>
+-#include <wpe/renderer-host.h>
++#include <wpe/wpe.h>
+ 
+ #ifdef BACKEND_BCM_NEXUS
+ #include "bcm-nexus/interfaces.h"
+diff --git a/src/realtek-wl-egl/interfaces.h b/src/realtek-wl-egl/interfaces.h
+index 36aa16b..7eaf033 100644
+--- a/src/realtek-wl-egl/interfaces.h
++++ b/src/realtek-wl-egl/interfaces.h
+@@ -28,8 +28,8 @@
+ #ifndef wayland_egl_interfaces_h
+ #define wayland_egl_interfaces_h
+ 
+-#include <wpe/renderer-backend-egl.h>
+-#include <wpe/view-backend.h>
++#include <wpe/wpe-egl.h>
++#include <wpe/wpe.h>
+ 
+ #ifdef __cplusplus
+ extern "C" {
+diff --git a/src/realtek-wl-egl/renderer-backend.cpp b/src/realtek-wl-egl/renderer-backend.cpp
+index cf46f17..2cbfd72 100644
+--- a/src/realtek-wl-egl/renderer-backend.cpp
++++ b/src/realtek-wl-egl/renderer-backend.cpp
+@@ -28,7 +28,7 @@
+ 
+ #include <wayland-egl.h>
+ 
+-#include <wpe/renderer-backend-egl.h>
++#include <wpe/wpe-egl.h>
+ 
+ #include "display.h"
+ #include "ipc.h"
+diff --git a/src/realtek-wl-egl/view-backend.cpp b/src/realtek-wl-egl/view-backend.cpp
+index 33b0fca..cd598fe 100644
+--- a/src/realtek-wl-egl/view-backend.cpp
++++ b/src/realtek-wl-egl/view-backend.cpp
+@@ -26,8 +26,7 @@
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  */
+ 
+-#include <wpe/input.h>
+-#include <wpe/view-backend.h>
++#include <wpe/wpe.h>
+ #include "display.h"
+ #include "ipc.h"
+ #include "ipc-waylandegl.h"
+diff --git a/src/viv-imx6/interfaces.h b/src/viv-imx6/interfaces.h
+index 27ef3fe..641871e 100644
+--- a/src/viv-imx6/interfaces.h
++++ b/src/viv-imx6/interfaces.h
+@@ -29,8 +29,8 @@
+ #ifndef viv_imx6_interfaces_h
+ #define viv_imx6_interfaces_h
+ 
+-#include <wpe/renderer-backend-egl.h>
+-#include <wpe/view-backend.h>
++#include <wpe/wpe-egl.h>
++#include <wpe/wpe.h>
+ 
+ #ifdef __cplusplus
+ extern "C" {
+diff --git a/src/viv-imx6/renderer-backend.cpp b/src/viv-imx6/renderer-backend.cpp
+index b5b9ed9..c4fd1ec 100644
+--- a/src/viv-imx6/renderer-backend.cpp
++++ b/src/viv-imx6/renderer-backend.cpp
+@@ -26,7 +26,7 @@
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  */
+ 
+-#include <wpe/renderer-backend-egl.h>
++#include <wpe/wpe-egl.h>
+ 
+ #include "ipc.h"
+ #include <EGL/egl.h>
+diff --git a/src/viv-imx6/view-backend.cpp b/src/viv-imx6/view-backend.cpp
+index b31fd13..2759c6f 100644
+--- a/src/viv-imx6/view-backend.cpp
++++ b/src/viv-imx6/view-backend.cpp
+@@ -26,7 +26,7 @@
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  */
+ 
+-#include <wpe/view-backend.h>
++#include <wpe/wpe.h>
+ 
+ #include "Libinput/LibinputServer.h"
+ #include "ipc.h"
+diff --git a/src/wayland-egl/interfaces.h b/src/wayland-egl/interfaces.h
+index 36aa16b..7eaf033 100644
+--- a/src/wayland-egl/interfaces.h
++++ b/src/wayland-egl/interfaces.h
+@@ -28,8 +28,8 @@
+ #ifndef wayland_egl_interfaces_h
+ #define wayland_egl_interfaces_h
+ 
+-#include <wpe/renderer-backend-egl.h>
+-#include <wpe/view-backend.h>
++#include <wpe/wpe-egl.h>
++#include <wpe/wpe.h>
+ 
+ #ifdef __cplusplus
+ extern "C" {
+diff --git a/src/wayland-egl/renderer-backend.cpp b/src/wayland-egl/renderer-backend.cpp
+index 118d97f..408aef1 100644
+--- a/src/wayland-egl/renderer-backend.cpp
++++ b/src/wayland-egl/renderer-backend.cpp
+@@ -28,7 +28,7 @@
+ 
+ #include <wayland-egl.h>
+ 
+-#include <wpe/renderer-backend-egl.h>
++#include <wpe/wpe-egl.h>
+ 
+ #include "display.h"
+ #include "ipc.h"
+diff --git a/src/wayland-egl/view-backend.cpp b/src/wayland-egl/view-backend.cpp
+index c8ead26..64a7903 100644
+--- a/src/wayland-egl/view-backend.cpp
++++ b/src/wayland-egl/view-backend.cpp
+@@ -26,8 +26,7 @@
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  */
+ 
+-#include <wpe/input.h>
+-#include <wpe/view-backend.h>
++#include <wpe/wpe.h>
+ #include "display.h"
+ #include "ipc.h"
+ #include "ipc-waylandegl.h"
+diff --git a/src/wayland/display.cpp b/src/wayland/display.cpp
+index 90f8d57..d7fe472 100644
+--- a/src/wayland/display.cpp
++++ b/src/wayland/display.cpp
+@@ -41,8 +41,7 @@
+ #include <sys/mman.h>
+ #include <unistd.h>
+ #include <wayland-client.h>
+-#include <wpe/input.h>
+-#include <wpe/view-backend.h>
++#include <wpe/wpe.h>
+ 
+ namespace Wayland {
+ 
+diff --git a/src/wayland/display.h b/src/wayland/display.h
+index 9543877..df265c0 100644
+--- a/src/wayland/display.h
++++ b/src/wayland/display.h
+@@ -30,7 +30,7 @@
+ #include <array>
+ #include <unordered_map>
+ #include <utility>
+-#include <wpe/input.h>
++#include <wpe/wpe.h>
+ #include <xkbcommon/xkbcommon-compose.h>
+ #include <xkbcommon/xkbcommon.h>
+ #include "ipc.h"
+diff --git a/src/westeros/WesterosViewbackendInput.cpp b/src/westeros/WesterosViewbackendInput.cpp
+index 017461c..0f85269 100644
+--- a/src/westeros/WesterosViewbackendInput.cpp
++++ b/src/westeros/WesterosViewbackendInput.cpp
+@@ -7,8 +7,7 @@
+ #include <locale.h>
+ #include <sys/mman.h>
+ #include <unistd.h>
+-#include <wpe/input.h>
+-#include <wpe/view-backend.h>
++#include <wpe/wpe.h>
+ 
+ namespace Westeros {
+ 
+diff --git a/src/westeros/WesterosViewbackendOutput.cpp b/src/westeros/WesterosViewbackendOutput.cpp
+index 4ac4d16..170a9c9 100644
+--- a/src/westeros/WesterosViewbackendOutput.cpp
++++ b/src/westeros/WesterosViewbackendOutput.cpp
+@@ -8,7 +8,7 @@
+ #include <locale.h>
+ #include <sys/mman.h>
+ #include <unistd.h>
+-#include <wpe/view-backend.h>
++#include <wpe/wpe.h>
+ 
+ namespace Westeros {
+ 
+diff --git a/src/westeros/interfaces.h b/src/westeros/interfaces.h
+index a832aee..a87b60f 100644
+--- a/src/westeros/interfaces.h
++++ b/src/westeros/interfaces.h
+@@ -28,8 +28,8 @@
+ #ifndef westeros_interfaces_h
+ #define westeros_interfaces_h
+ 
+-#include <wpe/renderer-backend-egl.h>
+-#include <wpe/view-backend.h>
++#include <wpe/wpe-egl.h>
++#include <wpe/wpe.h>
+ 
+ #ifdef __cplusplus
+ extern "C" {
+diff --git a/src/westeros/renderer-backend.cpp b/src/westeros/renderer-backend.cpp
+index 80d9a59..6921573 100644
+--- a/src/westeros/renderer-backend.cpp
++++ b/src/westeros/renderer-backend.cpp
+@@ -27,7 +27,7 @@
+ 
+ #define WL_EGL_PLATFORM 1
+ 
+-#include <wpe/renderer-backend-egl.h>
++#include <wpe/wpe-egl.h>
+ 
+ #include <stdio.h>
+ #include <cstring>
+diff --git a/src/westeros/view-backend.cpp b/src/westeros/view-backend.cpp
+index eb86487..1baec54 100644
+--- a/src/westeros/view-backend.cpp
++++ b/src/westeros/view-backend.cpp
+@@ -25,7 +25,7 @@
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  */
+ 
+-#include <wpe/view-backend.h>
++#include <wpe/wpe.h>
+ 
+ #include "WesterosViewbackendInput.h"
+ #include "WesterosViewbackendOutput.h"
+diff --git a/src/wpeframework/display.cpp b/src/wpeframework/display.cpp
+index 821b056..b361dc5 100644
+--- a/src/wpeframework/display.cpp
++++ b/src/wpeframework/display.cpp
+@@ -24,8 +24,7 @@
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  */
+ 
+-#include <wpe/input.h>
+-#include <wpe/view-backend.h>
++#include <wpe/wpe.h>
+ #include "display.h"
+ #include <cstring>
+ 
+diff --git a/src/wpeframework/display.h b/src/wpeframework/display.h
+index 5042507..60715b2 100644
+--- a/src/wpeframework/display.h
++++ b/src/wpeframework/display.h
+@@ -29,7 +29,7 @@
+ 
+ #include "ipc.h"
+ 
+-#include <wpe/input.h>
++#include <wpe/wpe.h>
+ #include <wayland/Client.h>
+ #include <xkbcommon/xkbcommon-compose.h>
+ #include <xkbcommon/xkbcommon.h>
+diff --git a/src/wpeframework/interfaces.h b/src/wpeframework/interfaces.h
+index d05b300..f38ccf0 100644
+--- a/src/wpeframework/interfaces.h
++++ b/src/wpeframework/interfaces.h
+@@ -28,8 +28,8 @@
+ #ifndef wpeframework_interfaces_h
+ #define wpeframework_interfaces_h
+ 
+-#include <wpe/renderer-backend-egl.h>
+-#include <wpe/view-backend.h>
++#include <wpe/wpe-egl.h>
++#include <wpe/wpe.h>
+ 
+ #ifdef __cplusplus
+ extern "C" {
+diff --git a/src/wpeframework/renderer-backend.cpp b/src/wpeframework/renderer-backend.cpp
+index cca2ea0..0a815f6 100644
+--- a/src/wpeframework/renderer-backend.cpp
++++ b/src/wpeframework/renderer-backend.cpp
+@@ -24,7 +24,7 @@
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  */
+ 
+-#include <wpe/renderer-backend-egl.h>
++#include <wpe/wpe-egl.h>
+ 
+ #include "display.h"
+ #include "ipc.h"
+diff --git a/src/wpeframework/view-backend.cpp b/src/wpeframework/view-backend.cpp
+index 5f3efd6..6c56681 100644
+--- a/src/wpeframework/view-backend.cpp
++++ b/src/wpeframework/view-backend.cpp
+@@ -26,8 +26,7 @@
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  */
+ 
+-#include <wpe/input.h>
+-#include <wpe/view-backend.h>
++#include <wpe/wpe.h>
+ #include "display.h"
+ #include "ipc.h"
+ #include "ipc-buffer.h"
+diff --git a/src/wpeframework/view-backend.old.cpp b/src/wpeframework/view-backend.old.cpp
+index 9266dce..2094553 100644
+--- a/src/wpeframework/view-backend.old.cpp
++++ b/src/wpeframework/view-backend.old.cpp
+@@ -26,8 +26,7 @@
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  */
+ 
+-#include <wpe/input.h>
+-#include <wpe/view-backend.h>
++#include <wpe/wpe.h>
+ #include "display.h"
+ #include "ipc.h"
+ #include "ipc-buffer.h"
+-- 
+2.11.0
+

--- a/recipes-browser/wpebackend-rdk/wpebackend-rdk/0001-WPEBackend-libraries-are-versioned-now.patch
+++ b/recipes-browser/wpebackend-rdk/wpebackend-rdk/0001-WPEBackend-libraries-are-versioned-now.patch
@@ -1,0 +1,36 @@
+From 254171f360ac0061eb14ca6303b3ce53cdf8f308 Mon Sep 17 00:00:00 2001
+From: Carlos Alberto Lopez Perez <clopez@igalia.com>
+Date: Mon, 14 May 2018 14:42:03 +0200
+Subject: [PATCH] WPEBackend libraries are versioned now.
+
+This fixes the build with WPEBackend after WPEBackend commit
+2d53b25913944b6974afb22aeeaed4cc44c665d2
+---
+ cmake/FindWPE.cmake | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/cmake/FindWPE.cmake b/cmake/FindWPE.cmake
+index c7a93d0..fb050ce 100644
+--- a/cmake/FindWPE.cmake
++++ b/cmake/FindWPE.cmake
+@@ -29,7 +29,7 @@
+ # ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ 
+ find_package(PkgConfig)
+-pkg_check_modules(PC_WPE QUIET wpe)
++pkg_check_modules(PC_WPE QUIET wpe-0.1)
+ 
+ find_path(WPE_INCLUDE_DIRS
+     NAMES wpe/loader.h
+@@ -37,7 +37,7 @@ find_path(WPE_INCLUDE_DIRS
+ )
+ 
+ find_library(WPE_LIBRARIES
+-    NAMES WPEBackend
++    NAMES WPEBackend-0.1
+     HINTS ${PC_WPE_LIBDIR} ${PC_WPE_LIBRARY_DIRS}
+ )
+ 
+-- 
+2.11.0
+

--- a/recipes-browser/wpebackend-rdk/wpebackend-rdk_1.20180411.bb
+++ b/recipes-browser/wpebackend-rdk/wpebackend-rdk_1.20180411.bb
@@ -1,0 +1,12 @@
+require wpebackend-rdk.inc
+
+DEPENDS = "wpebackend glib-2.0 libinput"
+
+SRCREV = "456f7c1470d0dba61399bd593f34a0b0316158cf"
+
+SRC_URI = " git://github.com/WebPlatformForEmbedded/WPEBackend-rdk.git;protocol=https;branch=master \
+            file://0001-WPEBackend-libraries-are-versioned-now.patch \
+            file://0001-Fix-include-of-headers-after-WPEBackend-commit-2bf3c.patch \
+          "
+
+S = "${WORKDIR}/git"

--- a/recipes-browser/wpebackend-rdk/wpebackend-rdk_1.20180925.bb
+++ b/recipes-browser/wpebackend-rdk/wpebackend-rdk_1.20180925.bb
@@ -1,14 +1,11 @@
 require wpebackend-rdk.inc
 
-DEFAULT_PREFERENCE = "-1"
-
 DEPENDS = "libwpe glib-2.0 libinput"
-PROVIDES += "virtual/wpebackend"
-RPROVIDES_${PN} += "virtual/wpebackend"
 
-PV = "git${AUTOREV}"
-SRCREV = "${AUTOREV}"
+PV = "1.20180925"
+SRCREV = "8ea61fbdee554a7cb2d1c1cbc53ce0868aaca304"
 
 SRC_URI = "git://github.com/WebPlatformForEmbedded/WPEBackend-rdk.git;protocol=https;branch=master"
 
 S = "${WORKDIR}/git"
+

--- a/recipes-browser/wpebackend/wpebackend.inc
+++ b/recipes-browser/wpebackend/wpebackend.inc
@@ -6,6 +6,9 @@ LICENSE = "BSD"
 LIC_FILES_CHKSUM = "file://COPYING;md5=6ae4db0d4b812334e1539cd5aa6e2f46"
 DEPENDS = "virtual/egl libxkbcommon"
 
+PROVIDES += "virtual/libwpe"
+RPROVIDES_${PN} += "virtual/libwpe"
+
 # Workaround build issue with RPi userland EGL libraries.
 CFLAGS_append_rpi = " ${@bb.utils.contains('MACHINE_FEATURES', 'vc4graphics', '', '-D_GNU_SOURCE', d)}"
 

--- a/recipes-browser/wpewebkit/wpewebkit.inc
+++ b/recipes-browser/wpewebkit/wpewebkit.inc
@@ -21,9 +21,7 @@ TOOLCHAIN = "gcc"
 PACKAGECONFIG ??= "fetchapi indexeddb mediasource video webaudio webcrypto woff2 gst_gl remote-inspector openjpeg"
 
 # WPE features
-
-## ROLLOUT: https://bugs.webkit.org/show_bug.cgi?id=195402
-# PACKAGECONFIG[bubblewrap] = "-DENABLE_BUBBLEWRAP_SANDBOX=ON,-DENABLE_BUBBLEWRAP_SANDBOX=OFF,bubblewrap bubblewrap-native xdg-dbus-proxy xdg-dbus-proxy-native libseccomp"
+PACKAGECONFIG[bubblewrap] = "-DENABLE_BUBBLEWRAP_SANDBOX=ON,-DENABLE_BUBBLEWRAP_SANDBOX=OFF,bubblewrap xdg-dbus-proxy bubblewrap-native xdg-dbus-proxy-native libseccomp"
 PACKAGECONFIG[deviceorientation] = "-DENABLE_DEVICE_ORIENTATION=ON,-DENABLE_DEVICE_ORIENTATION=OFF,"
 PACKAGECONFIG[encryptedmedia] = "-DENABLE_ENCRYPTED_MEDIA=ON,-DENABLE_ENCRYPTED_MEDIA=OFF,libgcrypt"
 PACKAGECONFIG[experimental-features] = "-DENABLE_EXPERIMENTAL_FEATURES=ON -DENABLE_WEB_RTC=OFF -DENABLE_MEDIA_STREAM=OFF,-DENABLE_EXPERIMENTAL_FEATURES=OFF,"

--- a/recipes-browser/wpewebkit/wpewebkit_2.20.2.bb
+++ b/recipes-browser/wpewebkit/wpewebkit_2.20.2.bb
@@ -8,4 +8,4 @@ SRC_URI[sha256sum] = "0950befe6e970c9219ccbc29f5ff08bcc0923f0a9ca5a4c7531d74f9e2
 
 DEPENDS += " wpebackend"
 
-RCONFLICTS_${PN} = "libwpe (>= 1.0) wpebackend-fdo (>= 1.0)"
+RCONFLICTS_${PN} = "wpebackend-rdk (> 1.20180411) libwpe (>= 1.0) wpebackend-fdo (>= 1.0)"


### PR DESCRIPTION
* cog:
  * Added cog 0.2.0 recipe based on tarball release.
  * Added run conflict with wpewebkit (>= 2.21) in cog-0.1.1
  * Added run conflict with wpebackend-rdk (> 1.20180411) in cog-0.20.2
* virtual/libwpe:
  * libwpe provides virtual/libwpe
  * wpebackend also provides virtual/libwpe
* wpebackend-rdk:
  * Restored wpebackend-rdk (1.20180411). Still needed to build the
    wpewebkit-2.20.2 recipe:

      commit 2b4ea01
      Author: Zan Dobersek <zdobersek@igalia.com>
      Date:   Fri Sep 28 08:29:54 2018 +0200

      wpebackend-rdk: bump the version, fix deps, remove
      unnecessary patches.

  * Common definitions isolated in wpebackend-rdk.inc
  * wpebackend-rdk-git remamed to 1.20180925
  * New wpebackend-rdk-git points to the master HEAD