### PR TITLE
Required recipes to build images and toolchains to build WPE

### DIFF
--- a/classes/ruby.bbclass
+++ b/classes/ruby.bbclass
@@ -1,0 +1,168 @@
+DEPENDS += " \
+    ruby-native \
+"
+RDEPENDS_${PN} += " \
+    ruby \
+"
+
+#${PN}_do_compile[depends] += "ruby-native:do_populate_sysroot"
+
+def get_rubyversion(p):
+    import re
+    from os.path import isfile
+    import subprocess
+    found_version = "SOMETHING FAILED!"
+
+    cmd = "%s/ruby" % p
+
+    if not isfile(cmd):
+       return found_version
+
+    version = subprocess.Popen([cmd, "--version"], stdout=subprocess.PIPE).communicate()[0]
+
+    r = re.compile("ruby ([0-9]+\.[0-9]+\.[0-9]+)*")
+    m = r.match(version)
+    if m:
+        found_version = m.group(1)
+
+    return found_version
+
+def get_rubygemslocation(p):
+    import re
+    from os.path import isfile
+    import subprocess
+    found_loc = "SOMETHING FAILED!"
+
+    cmd = "%s/gem" % p
+
+    if not isfile(cmd):
+       return found_loc
+
+    loc = subprocess.Popen([cmd, "env"], stdout=subprocess.PIPE).communicate()[0]
+
+    r = re.compile(".*\- (/usr.*/ruby/gems/.*)")
+    for line in loc.split('\n'):
+        m = r.match(line)
+        if m:
+            found_loc = m.group(1)
+            break
+
+    return found_loc
+
+def get_rubygemsversion(p):
+    import re
+    from os.path import isfile
+    import subprocess
+    found_version = "SOMETHING FAILED!"
+
+    cmd = "%s/gem" % p
+
+    if not isfile(cmd):
+       return found_version
+
+    version = subprocess.Popen([cmd, "env", "gemdir"], stdout=subprocess.PIPE).communicate()[0]
+
+    r = re.compile(".*([0-9]+\.[0-9]+\.[0-9]+)$")
+    m = r.match(version.decode("utf-8"))
+    if m:
+        found_version = m.group(1)
+
+    return found_version
+
+RUBY_VERSION ?= "${@get_rubyversion("${STAGING_BINDIR_NATIVE}")}"
+RUBY_GEM_DIRECTORY ?= "${@get_rubygemslocation("${STAGING_BINDIR_NATIVE}")}"
+RUBY_GEM_VERSION ?= "${@get_rubygemsversion("${STAGING_BINDIR_NATIVE}")}"
+
+export GEM_HOME = "${STAGING_DIR_NATIVE}/usr/lib/ruby/gems/${RUBY_GEM_VERSION}"
+
+RUBY_BUILD_GEMS ?= "${BPN}.gemspec"
+RUBY_INSTALL_GEMS ?= "${BPN}-${BPV}.gem"
+
+RUBY_COMPILE_FLAGS ?= 'LANG="en_US.UTF-8" LC_ALL="en_US.UTF-8"'
+
+ruby_gen_extconf_fix() {
+	cat<<EOF>append
+  RbConfig::MAKEFILE_CONFIG['CPPFLAGS'] = ENV['CPPFLAGS'] if ENV['CPPFLAGS']
+  \$CPPFLAGS = ENV['CPPFLAGS'] if ENV['CPPFLAGS']
+  RbConfig::MAKEFILE_CONFIG['CC'] = ENV['CC'] if ENV['CC']
+  RbConfig::MAKEFILE_CONFIG['LD'] = ENV['LD'] if ENV['LD']
+  RbConfig::MAKEFILE_CONFIG['CFLAGS'] = ENV['CFLAGS'] if ENV['CFLAGS']
+  RbConfig::MAKEFILE_CONFIG['CXXFLAGS'] = ENV['CXXFLAGS'] if ENV['CXXFLAGS']
+EOF
+	cat append2>>append
+	sysroot_ruby=${STAGING_INCDIR}/ruby-${RUBY_GEM_VERSION}
+	ruby_arch=`ls -1 ${sysroot_ruby} |grep -v ruby |tail -1 2> /dev/null`
+	cat<<EOF>>append
+  system("perl -p -i -e 's#^topdir.*#topdir = ${sysroot_ruby}#' Makefile")
+  system("perl -p -i -e 's#^hdrdir.*#hdrdir = ${sysroot_ruby}#' Makefile")
+  system("perl -p -i -e 's#^arch_hdrdir.*#arch_hdrdir = ${sysroot_ruby}/\\\\\$(arch)#' Makefile")
+  system("perl -p -i -e 's#^arch =.*#arch = ${ruby_arch}#' Makefile")
+  system("perl -p -i -e 's#^LIBPATH =.*#LIBPATH = -L.#' Makefile")
+  system("perl -p -i -e 's#^dldflags =.*#dldflags = ${LDFLAGS}#' Makefile")
+  system("perl -p -i -e 's#^ldflags  =.*#ldflags = -L${STAGING_LIBDIR}#' Makefile")
+EOF
+}
+
+
+ruby_do_compile() {
+        EXTCONF_FILES=$(find . -name extconf.rb -exec ls {} \;)
+        for e in $EXTCONF_FILES
+        do
+            if [ -f $e -a ! -f $e.orig ] ; then
+                grep create_makefile $e > append2 || continue
+                ruby_gen_extconf_fix
+                cp $e $e.orig
+                # Patch extconf.rb for cross compile
+                cat append >> $e
+            fi
+        done
+        for gem in ${RUBY_BUILD_GEMS}; do
+                ${RUBY_COMPILE_FLAGS} gem build $gem
+        done
+        for e in $EXTCONF_FILES
+        do
+            if [ -f $e.orig ] ; then
+                mv $e.orig $e
+            fi
+        done
+}
+
+ruby_do_install() {
+	for gem in ${RUBY_INSTALL_GEMS}; do
+		gem install --ignore-dependencies --local --env-shebang --install-dir ${D}/${libdir}/ruby/gems/${RUBY_GEM_VERSION}/ $gem
+	done
+
+	# create symlink from the gems bin directory to /usr/bin
+	for i in ${D}/${libdir}/ruby/gems/${RUBY_GEM_VERSION}/bin/*; do
+		if [ -e "$i" ]; then
+			if [ ! -d ${D}/${bindir} ]; then mkdir -p ${D}/${bindir}; fi
+			b=`basename $i`
+			ln -sf ${libdir}/ruby/gems/${RUBY_GEM_VERSION}/bin/$b ${D}/${bindir}/$b
+		fi
+	done
+}
+
+EXPORT_FUNCTIONS do_compile do_install
+
+PACKAGES = "${PN}-dbg ${PN} ${PN}-doc ${PN}-dev"
+
+FILES_${PN}-dbg += " \
+        ${libdir}/ruby/gems/${RUBY_GEM_VERSION}/gems/*/*/.debug \
+        ${libdir}/ruby/gems/${RUBY_GEM_VERSION}/gems/*/*/*/.debug \
+        ${libdir}/ruby/gems/${RUBY_GEM_VERSION}/gems/*/*/*/*/.debug \
+        ${libdir}/ruby/gems/${RUBY_GEM_VERSION}/gems/*/*/*/*/*/.debug \
+        ${libdir}/ruby/gems/${RUBY_GEM_VERSION}/extensions/*/*/*/*/*/.debug \
+        "
+
+FILES_${PN} += " \
+        ${libdir}/ruby/gems/${RUBY_GEM_VERSION}/gems \
+        ${libdir}/ruby/gems/${RUBY_GEM_VERSION}/cache \
+        ${libdir}/ruby/gems/${RUBY_GEM_VERSION}/bin \
+        ${libdir}/ruby/gems/${RUBY_GEM_VERSION}/specifications \
+        ${libdir}/ruby/gems/${RUBY_GEM_VERSION}/build_info \
+        ${libdir}/ruby/gems/${RUBY_GEM_VERSION}/extensions \
+        "
+
+FILES_${PN}-doc += " \
+        ${libdir}/ruby/gems/${RUBY_GEM_VERSION}/doc \
+        "

--- a/recipes-browser/packagegroups/packagegroup-wpewebkit-depends.bb
+++ b/recipes-browser/packagegroups/packagegroup-wpewebkit-depends.bb
@@ -1,0 +1,277 @@
+inherit packagegroup
+
+PACKAGES = " \
+    packagegroup-wpewebkit-depends \
+    packagegroup-wpewebkit-depends-sys-extended \
+    packagegroup-wpewebkit-depends-perl \
+    packagegroup-wpewebkit-depends-python \
+    packagegroup-wpewebkit-depends-misc \
+    packagegroup-wpewebkit-depends-core \
+    packagegroup-wpewebkit-depends-desktop \
+    packagegroup-wpewebkit-depends-runtime-add \
+    packagegroup-wpewebkit-depends-alternative \
+    packagegroup-wpewebkit-depends-video \
+    packagegroup-wpewebkit-depends-extra \
+    packagegroup-wpewebkit-depends-tests \
+"
+
+RDEPENDS_packagegroup-wpewebkit-depends = "\
+    packagegroup-wpewebkit-depends-sys-extended \
+    packagegroup-wpewebkit-depends-perl \
+    packagegroup-wpewebkit-depends-python \
+    packagegroup-wpewebkit-depends-misc \
+    packagegroup-wpewebkit-depends-core \
+    packagegroup-wpewebkit-depends-desktop \
+    packagegroup-wpewebkit-depends-runtime-add \
+    packagegroup-wpewebkit-depends-alternative \
+    packagegroup-wpewebkit-depends-video \
+    packagegroup-wpewebkit-depends-extra \
+    packagegroup-wpewebkit-depends-tests \
+"
+
+RDEPENDS_packagegroup-wpewebkit-depends-sys-extended = "\
+    curl \
+    dhcp-client \
+    hdparm \
+    libaio \
+    lzo \
+    tmux \
+    sysstat \
+    unzip \
+    watchdog \
+    wget \
+    which \
+    zip \
+    "
+
+RDEPENDS_packagegroup-wpewebkit-depends-perl = "\
+    gdbm \
+    perl \
+    perl-modules \
+    perl-misc \
+    perl-pod \
+    perl-dev \
+    zlib \
+"
+
+RDEPENDS_packagegroup-wpewebkit-depends-python = "\
+    expat \
+    gdbm \
+    gmp \
+    ncurses \
+    openssl \
+    python \
+    python \
+    python-modules \
+    python-misc \
+    readline \
+    zip \
+"
+
+RDEPENDS_packagegroup-wpewebkit-depends-misc = "\
+    chkconfig \
+    gettext \
+    gettext-runtime \
+    groff \
+    lsof \
+    strace \
+    libusb1 \
+    usbutils \
+    rpm \
+    "
+
+RDEPENDS_packagegroup-wpewebkit-depends-core = "\
+    at \
+    bash \
+    bc \
+    binutils \
+    binutils-symlinks \
+    bzip2 \
+    coreutils \
+    cpio \
+    cronie \
+    diffutils \
+    ed \
+    glibc-utils \
+    elfutils \
+    file \
+    findutils \
+    fontconfig-utils \
+    gawk \
+    grep \
+    gzip \
+    localedef \
+    make \
+    msmtp \
+    patch \
+    procps \
+    psmisc \
+    sed \
+    shadow \
+    tar \
+    time \
+    util-linux \
+    xdg-utils \
+    glibc \
+    libgcc \
+    libpam \
+    libxml2 \
+    ncurses \
+    zlib \
+    nspr \
+    nss \
+    bison \
+    gperf \
+    libxml2 \
+    ruby \
+    cairo \
+    fontconfig \
+    freetype \
+    glib-2.0 \
+    gnutls \
+    harfbuzz \
+    harfbuzz-icu \
+    icu \
+    jpeg \
+    sqlite3 \
+    zlib \
+    libpng \
+    libsoup-2.4 \
+    libwebp \
+    libxml2 \
+    libxslt \
+    libepoxy \
+    libgcrypt \
+    bubblewrap \
+    xdg-dbus-proxy \
+    libseccomp \
+    libicudata \
+"
+
+RDEPENDS_packagegroup-wpewebkit-depends-desktop = "\
+    libxt \
+    libxxf86vm \
+    libdrm \
+    libglu \
+    libxi \
+    libxtst \
+    libx11-locale \
+    xorg-minimal-fonts \
+    gdk-pixbuf-loader-ico \
+    gdk-pixbuf-loader-bmp \
+    gdk-pixbuf-loader-ani \
+    gdk-pixbuf-xlib \
+    liberation-fonts \
+    atk \
+    at-spi2-atk \
+    alsa-lib \
+"
+
+RDEPENDS_packagegroup-wpewebkit-depends-runtime-add = "\
+    ldd \
+    e2fsprogs-mke2fs \
+    mkfontdir \
+    liburi-perl \
+    libxml-parser-perl \
+    libxml-perl \
+    libxml-sax-perl \
+    glibc-localedatas \
+    glibc-gconvs \
+    glibc-charmaps \
+    glibc-binaries \
+    glibc-localedata-posix \
+    glibc-extra-nss \
+    glibc-pcprofile \
+"
+
+RDEPENDS_packagegroup-wpewebkit-depends-alternative = " \
+    geoclue \
+    libtasn1 \
+    woff2 \
+    libvpx \
+    libevent \
+    libopus \
+    openjpeg \
+"
+
+RDEPENDS_packagegroup-wpewebkit-depends-video = " \
+    gstreamer1.0 \
+    gstreamer1.0-plugins-base \
+    gstreamer1.0-plugins-good \
+    gstreamer1.0-plugins-bad \
+    gstreamer1.0-plugins-good-isomp4 \
+    gstreamer1.0-plugins-good-wavparse \
+    gstreamer1.0-plugins-base-opengl \
+    gstreamer1.0-plugins-base-app \
+    gstreamer1.0-plugins-base-playback \
+    gstreamer1.0-plugins-good-souphttpsrc \
+    gstreamer1.0-plugins-base-audioconvert \
+    gstreamer1.0-plugins-base-audioresample \
+    gstreamer1.0-plugins-base-gio \
+    gstreamer1.0-plugins-base-videoconvert \
+    gstreamer1.0-plugins-base-videoscale \
+    gstreamer1.0-plugins-base-volume \
+    gstreamer1.0-plugins-base-typefindfunctions \
+    gstreamer1.0-plugins-good-audiofx \
+    gstreamer1.0-plugins-good-audioparsers \
+    gstreamer1.0-plugins-good-autodetect \
+    gstreamer1.0-plugins-good-avi \
+    gstreamer1.0-plugins-good-deinterlace \
+    gstreamer1.0-plugins-good-interleave \
+    gstreamer1.0-plugins-bad-dashdemux \
+    gstreamer1.0-plugins-bad-mpegtsdemux \
+    gstreamer1.0-plugins-bad-smoothstreaming \
+    gstreamer1.0-plugins-bad-videoparsersbad \
+"
+
+RDEPENDS_packagegroup-wpewebkit-depends-extra = " \
+    ca-certificates \
+    shared-mime-info \
+    ttf-bitstream-vera \
+    gstreamer1.0-plugins-base-meta \
+    gstreamer1.0-plugins-good-meta \
+    gstreamer1.0-plugins-bad-meta \
+"
+
+RDEPENDS_packagegroup-wpewebkit-depends-tests = " \
+    pkgconfig \
+    p7zip \
+    git \
+    subversion \
+    bzip2 \
+    apache2 \
+    apache2-scripts \
+    curl \
+    gdb \
+    php \
+    python \
+    python-subprocess32 \
+    python-pygobject \
+    python-psutil \
+    psmisc \
+    pulseaudio \
+    pulseaudio-misc \
+    perl \
+    perl-module-file-spec \
+    perl-module-cgi \
+    test-dicts \
+    webkit-test-fonts \
+    ruby \
+    ruby-highline \
+    ruby-json \
+    brotli \
+    libsoup-2.4 \
+    cairo \
+    fontconfig \
+    freetype \
+    harfbuzz \
+    icu \
+    woff2 \
+    libwpe \
+    wpebackend-fdo \
+    libgpg-error \
+    libgcrypt \
+    libepoxy \
+    wayland-protocols \
+    openjpeg \
+"

--- a/recipes-browser/packagegroups/packagegroup-wpewebkit-depends.bb
+++ b/recipes-browser/packagegroups/packagegroup-wpewebkit-depends.bb
@@ -154,6 +154,7 @@ RDEPENDS_packagegroup-wpewebkit-depends-desktop = "\
     libdrm \
     libglu \
     libxi \
+    libxkbcommon \
     libxtst \
     libx11-locale \
     xorg-minimal-fonts \

--- a/recipes-browser/packagegroups/packagegroup-wpewebkit-depends.bb
+++ b/recipes-browser/packagegroups/packagegroup-wpewebkit-depends.bb
@@ -69,7 +69,6 @@ RDEPENDS_packagegroup-wpewebkit-depends-python = "\
 "
 
 RDEPENDS_packagegroup-wpewebkit-depends-misc = "\
-    chkconfig \
     gettext \
     gettext-runtime \
     groff \

--- a/recipes-devtools/dicts/test-dicts_git.bb
+++ b/recipes-devtools/dicts/test-dicts_git.bb
@@ -1,0 +1,31 @@
+LICENSE = "GPLv2"
+LIC_FILES_CHKSUM = "file://LICENSE.en_US;md5=370dfc0dcc9918290a76eeb1e761f377"
+
+PR = "r0"
+
+BPV = "0.0.1"
+PV = "${BPV}"
+SRCREV = "a63aa52f09ddbf2532304a5751d22e5712299b0d"
+
+S = "${WORKDIR}/git"
+
+SRC_URI = " \
+    git://github.com/mrobinson/webkitgtk-test-dicts.git;protocol=https;branch=master \
+    "
+
+do_configure() {
+}
+
+do_compile() {
+}
+
+do_install() {
+   cd ${S}
+   export DESTDIR=${D}
+   JHBUILD_PREFIX=""
+   make install
+}
+
+FILES_${PN} = " \
+/webkitgtk-test-dicts/* \
+"

--- a/recipes-devtools/fonts/webkit-test-fonts_git.bb
+++ b/recipes-devtools/fonts/webkit-test-fonts_git.bb
@@ -1,0 +1,31 @@
+LICENSE = "GPLv2"
+LIC_FILES_CHKSUM = "file://LICENSE.dejavu;md5=b48ab4e9977f6f7d9eb9481bb69a219d"
+
+PR = "r0"
+
+BPV = "0.0.8"
+PV = "${BPV}"
+SRCREV = "f6382ed93932cca128c8d9edec3088f85a7592d9"
+
+S = "${WORKDIR}/git"
+
+SRC_URI = " \
+    git://github.com/WebKitGTK/webkitgtk-test-fonts.git;protocol=https;branch=master \
+    "
+
+do_configure() {
+}
+
+do_compile() {
+}
+
+do_install() {
+   cd ${S}
+   export DESTDIR=${D}
+   JHBUILD_PREFIX=""
+   make install
+}
+
+FILES_${PN} = " \
+/webkitgtk-test-fonts/* \
+"

--- a/recipes-devtools/ruby/ruby-highline/fix-spec-files.patch
+++ b/recipes-devtools/ruby/ruby-highline/fix-spec-files.patch
@@ -1,0 +1,13 @@
+diff --git a/highline.gemspec b/highline.gemspec
+index 9523c0f..6c8c419 100644
+--- a/highline.gemspec
++++ b/highline.gemspec
+@@ -10,7 +10,7 @@ SPEC = Gem::Specification.new do |spec|
+   spec.version  = GEM_VERSION
+   spec.platform = Gem::Platform::RUBY
+   spec.summary  = "HighLine is a high-level command-line IO library."
+-  spec.files    = `git ls-files`.split("\n")
++  spec.files    = `git ls-files | grep -v COPYING | grep -v .gitignore | grep -v .cvsignore | grep -v .travis.yml | grep -v AUTHORS`.split("\n")
+
+   spec.test_files       =  `git ls-files -- test/*.rb`.split("\n")
+   spec.has_rdoc         =  true

--- a/recipes-devtools/ruby/ruby-highline_git.bb
+++ b/recipes-devtools/ruby/ruby-highline_git.bb
@@ -1,0 +1,34 @@
+#
+# Copyright (C) 2014 Wind River Systems, Inc.
+#
+SUMMARY = "Provides a robust system for requesting data from a user."
+DESCRIPTION = "HighLine was designed to ease the tedious tasks of \
+doing console input and output with low-level methods like gets() and \
+puts(). HighLine provides a robust system for requesting data from a \
+user, without needing to code all the error checking and validation \
+rules and without needing to convert the typed Strings into what your \
+program really needs. Just tell HighLine what you're after, and let it \
+do all the work."
+
+LICENSE = "GPLv2"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=884766faee6a0d2931af978757e1a5fc"
+
+PR = "r0"
+
+BPV = "1.7.3"
+PV = "${BPV}"
+SRCREV = "327051c1c217df2880c3a53f31484f7e815e847f"
+
+S = "${WORKDIR}/git"
+
+RUBY_GEM_NAME="highline"
+RUBY_BUILD_GEMS="${RUBY_GEM_NAME}.gemspec"
+RUBY_INSTALL_GEMS ?= "${RUBY_GEM_NAME}-${PV}.gem"
+
+SRC_URI = " \
+    git://github.com/JEG2/highline.git \
+    "
+
+inherit ruby
+
+BBCLASSEXTEND = "native"

--- a/recipes-devtools/ruby/ruby-json_1.8.6.bb
+++ b/recipes-devtools/ruby/ruby-json_1.8.6.bb
@@ -1,0 +1,36 @@
+#
+# Copyright (C) 2014 Wind River Systems, Inc.
+#
+SUMMARY = "An implementation of the JSON specification according to RFC 4627"
+DESCRIPTION = "An implementation of the JSON specification according to RFC 4627"
+
+LICENSE = "GPLv2"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/GPL-2.0;md5=801f80980d171dd6425610833a22dbe6"
+
+PR = "r0"
+
+BPV = "1.8.6"
+PV = "${BPV}"
+
+FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
+
+SRCREV = "7f4cfd853f2c919d854fb95548a19980feff17e8"
+
+S = "${WORKDIR}/git"
+
+RUBY_GEM_NAME="json"
+RUBY_BUILD_GEMS="${RUBY_GEM_NAME}.gemspec"
+RUBY_INSTALL_GEMS ?= "${RUBY_GEM_NAME}-${PV}.gem"
+
+SRC_URI = " \
+    git://github.com/flori/json.git;protocol=https;branch=v1.8 \
+    "
+
+inherit ruby
+
+DEPENDS += " \
+    ruby \
+    virtual/crypt \
+"
+
+BBCLASSEXTEND = "native"


### PR DESCRIPTION
* Add packagegroup-wpewebkit-depends. Need to build images and toolchains with all the dependencies to build or run WebKit but without WebKit
* wpewebkit: bumb trunk version (compatible with wpe-1.0)
* Add required recipes to build to run the WebKit Layout tests
  * ~~reverted a patch in Ruby recipe. This is needed to build the Ruby packages from meta-cloud-services/meta-openstack~~
  * added json and highline ruby packages
  * added mrobinson's dicts and fonts resources