### PR TITLE
add recipe for cog 0.2.0 and make it default

### DIFF
--- a/recipes-browser/cog/cog_0.2.0.bb
+++ b/recipes-browser/cog/cog_0.2.0.bb
@@ -1,0 +1,8 @@
+require cog.inc
+
+SRC_URI = "https://github.com/Igalia/${PN}/archive/v${PV}.tar.gz"
+
+SRC_URI[md5sum] = "3161a6260cb95f273cebf598bb3fcb92"
+SRC_URI[sha256sum] = "a6abadb78395226bac2e1dd5467feab2cc8c493eab6894a09a51a8e072e38c06"
+
+RCONFLICTS_${PN} = "wpewebkit (>= 2.23)"

--- a/recipes-browser/cog/cog_git.bb
+++ b/recipes-browser/cog/cog_git.bb
@@ -4,3 +4,5 @@ PV = "git${AUTOREV}"
 SRCREV = "${AUTOREV}"
 SRC_URI = " git://github.com/Igalia/cog.git;protocol=https;branch=master"
 S = "${WORKDIR}/git"
+
+DEFAULT_PREFERENCE = "-1"


### PR DESCRIPTION
By default cog_git would be selected to be used but that does not work as its Version 0.3.0 which depends on wpewebkit 2.24 but only 2.22 is available in sumo.

Cog 0.2.0 on the other hand works with wepewebkit 2.22.

The recipe is copied from master