### PR TITLE
[wpe-webkit] Bumping up WPE WebKit to 2.24.1 (refs: #94)

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -9,7 +9,7 @@ thud-wandboard-mesa-weston-wpe-2.20:
     - pushd sources/meta-webkit
     - git checkout $CI_COMMIT_SHA
     - popd
-    - source setup-environment wandboard-mesa-wpe-2.20 --update-config
+    - source setup-environment wandboard-mesa-wpe-2.20 wandboard-mesa browsers wandboard mesa-wpe-2_20 --update-config
     - rm -rf tmp
     - bitbake core-image-weston-wpe
 
@@ -24,7 +24,22 @@ thud-wandboard-mesa-weston-wpe-2.22:
     - pushd sources/meta-webkit
     - git checkout $CI_COMMIT_SHA
     - popd
-    - source setup-environment wandboard-mesa-wpe-2.22 --update-config
+    - source setup-environment wandboard-mesa-wpe-2.22 wandboard-mesa browsers wandboard mesa-wpe-2_22 --update-config
+    - rm -rf tmp
+    - bitbake core-image-weston-wpe
+
+thud-wandboard-mesa-weston-wpe-2.24:
+  tags:
+    - meta-webkit
+  script:
+    - mkdir -p ~/yocto-wandboard-wpe
+    - cd ~/yocto-wandboard-wpe
+    - repo init -u https://gitlab.com/saavedra.pablo/meta-perf-browser.git -m manifest.xml -b nightly
+    - repo sync --force-sync
+    - pushd sources/meta-webkit
+    - git checkout $CI_COMMIT_SHA
+    - popd
+    - source setup-environment wandboard-mesa-wpe-2.24 wandboard-mesa browsers wandboard mesa-wpe-2_24 --update-config
     - rm -rf tmp
     - bitbake core-image-weston-wpe
 
@@ -40,7 +55,7 @@ thud-wandboard-mesa-weston-wpe-trunk:
     - pushd sources/meta-webkit
     - git checkout $CI_COMMIT_SHA
     - popd
-    - source setup-environment wandboard-mesa-wpe-trunk --update-config
+    - source setup-environment wandboard-mesa-wpe-trunk wandboard-mesa browsers wandboard mesa-wpe-trunk --update-config
     - rm -rf tmp
     - bitbake core-image-weston-wpe
 
@@ -56,21 +71,21 @@ thud-wandboard-mesa-weston-wpe-qt:
     - pushd sources/meta-webkit
     - git checkout $CI_COMMIT_SHA
     - popd
-    - source setup-environment wandboard-mesa-wpe-qt --update-config
+    - source setup-environment wandboard-mesa-wpe-qt wandboard-mesa browsers wandboard mesa-wpe-qt --update-config
     - rm -rf tmp
     - bitbake core-image-weston-wpe
 
-thud-rpi3-vc4graphics-wpe-2.22:
+thud-rpi3-userland-wpe-2.22:
   tags:
     - meta-webkit
   script:
-    - mkdir -p ~/yocto-vc4graphics-wpe
-    - cd ~/yocto-vc4graphics-wpe
+    - mkdir -p ~/yocto-rpi3-wpe
+    - cd ~/yocto-rpi3-wpe
     - repo init -u https://gitlab.com/saavedra.pablo/meta-perf-browser.git -m manifest.xml -b nightly
     - repo sync --force-sync
     - pushd sources/meta-webkit
     - git checkout $CI_COMMIT_SHA
     - popd
-    - source setup-environment rpi3-vc4graphics-wpe-2.22 --update-config
+    - source setup-environment rpi3-userland-wpe-2.22 raspberrypi3-userland browsers raspberrypi3 userland-wpe-2_22 --update-config
     - rm -rf tmp
     - bitbake core-image-wpe

--- a/recipes-browser/wpewebkit/wpewebkit_2.24.1.bb
+++ b/recipes-browser/wpewebkit/wpewebkit_2.24.1.bb
@@ -4,7 +4,7 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 SRC_URI = "https://wpewebkit.org/releases/${PN}-${PV}.tar.xz \
           "
 
-SRC_URI[md5sum] = "042848cd0d0f9f7fa54663db8e4751dc"
-SRC_URI[sha256sum] = "d2e5e444134720cbad5c8669996000a004943bb71ee6783aefa72a80bde1b35a"
+SRC_URI[md5sum] = "0f7b792874853416d8005b020bd90685"
+SRC_URI[sha256sum] = "95f2fb68429fbd901ea415d09fdd88d6d9ac5ec2d170bec9977093b12e5093a6"
 
 DEPENDS += " libwpe"


### PR DESCRIPTION
```
WPE WebKit 2.24.1 is available for download at:

https://wpewebkit.org/releases/wpewebkit-2.24.1.tar.xz (16.1MB)
   md5sum: 0f7b792874853416d8005b020bd90685
   sha1sum: d009c82afbc2c373a7f34ffda392e5c3b52dac7d
   sha256sum: 95f2fb68429fbd901ea415d09fdd88d6d9ac5ec2d170bec9977093b12e5093a6

This is the first bug fix release in the stable 2.24 series.

What's new in the WPE WebKit 2.24.1 release?
============================================


  - Do not allow changes in active URI before provisional load starts for non-API requests.
  - Stop the threaded compositor when the page is not visible or layer tree state is frozen.
  - Use WebKit HTTP source element again for adaptive streaming fragments downloading.
  - Properly handle empty resources in webkit_web_resource_get_data().
  - Add quirk to ensure outlook.live.com uses the modern UI.
  - Fix methods returing GObject or boxed types in JavaScriptCore GLib API.
  - Ensure callback data is passed to functions and constructors with no parameters in JavaScriptCore GLib API.
  - Fix rendering of complex text when the font uses x,y origins.
  - Fix sound loop with Google Hangouts and WhatsApp notifications.
  - Fix the build with GStreamer 1.12.5 and GST GL enabled.
  - Fix event source priorities to avoid starvation causing the NetworkProcess to be killed in constraned environments.
  - Detect SSE2 at compile time.
  - Fix several crashes and rendering issues.
  - Security fixes: CVE-2019-6251.
```