### PR TITLE
wpebackend-fdo: Fix cmake to use the wayland-scanner

### DIFF
--- a/recipes-browser/wpebackend-fdo/wpebackend-fdo/PKG_CONFIG_SYSROOT_DIR_for_wayland_scanner.patch
+++ b/recipes-browser/wpebackend-fdo/wpebackend-fdo/PKG_CONFIG_SYSROOT_DIR_for_wayland_scanner.patch
@@ -1,0 +1,17 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 8a94387..5cb9a38 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -94,9 +94,9 @@ add_custom_command(
+            ${CMAKE_BINARY_DIR}/bridge/wpe-bridge-client-protocol.h
+            ${CMAKE_BINARY_DIR}/bridge/wpe-bridge-server-protocol.h
+     DEPENDS ${CMAKE_SOURCE_DIR}/src/bridge/wpe-bridge.xml
+-    COMMAND ${WAYLAND_SCANNER} ${WAYLAND_SCANNER_CODE_ARG} < ${CMAKE_SOURCE_DIR}/src/bridge/wpe-bridge.xml > ${CMAKE_BINARY_DIR}/bridge/wpe-bridge-protocol.c
+-    COMMAND ${WAYLAND_SCANNER} client-header < ${CMAKE_SOURCE_DIR}/src/bridge/wpe-bridge.xml > ${CMAKE_BINARY_DIR}/bridge/wpe-bridge-client-protocol.h
+-    COMMAND ${WAYLAND_SCANNER} server-header < ${CMAKE_SOURCE_DIR}/src/bridge/wpe-bridge.xml > ${CMAKE_BINARY_DIR}/bridge/wpe-bridge-server-protocol.h
++    COMMAND $ENV{PKG_CONFIG_SYSROOT_DIR}-native${WAYLAND_SCANNER} ${WAYLAND_SCANNER_CODE_ARG} < ${CMAKE_SOURCE_DIR}/src/bridge/wpe-bridge.xml > ${CMAKE_BINARY_DIR}/bridge/wpe-bridge-protocol.c
++    COMMAND $ENV{PKG_CONFIG_SYSROOT_DIR}-native${WAYLAND_SCANNER} client-header < ${CMAKE_SOURCE_DIR}/src/bridge/wpe-bridge.xml > ${CMAKE_BINARY_DIR}/bridge/wpe-bridge-client-protocol.h
++    COMMAND $ENV{PKG_CONFIG_SYSROOT_DIR}-native${WAYLAND_SCANNER} server-header < ${CMAKE_SOURCE_DIR}/src/bridge/wpe-bridge.xml > ${CMAKE_BINARY_DIR}/bridge/wpe-bridge-server-protocol.h
+     VERBATIM
+ )
+

--- a/recipes-browser/wpebackend-fdo/wpebackend-fdo_1.0.1.bb
+++ b/recipes-browser/wpebackend-fdo/wpebackend-fdo_1.0.1.bb
@@ -1,6 +1,9 @@
 require wpebackend-fdo.inc
 
+FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
+
 SRC_URI = "https://wpewebkit.org/releases/${PN}-${PV}.tar.xz"
+SRC_URI += "file://PKG_CONFIG_SYSROOT_DIR_for_wayland_scanner.patch"
 SRC_URI[md5sum] = "2ee81a4212c18110a06a0c51c12e0d2e"
 SRC_URI[sha256sum] = "15b8b1febea5d9c271e95c35b3c1e13f870712a54bc5f689cfdbb96e2f070fc8"
 

--- a/recipes-browser/wpebackend-fdo/wpebackend-fdo_1.2.0.bb
+++ b/recipes-browser/wpebackend-fdo/wpebackend-fdo_1.2.0.bb
@@ -1,6 +1,9 @@
 require wpebackend-fdo.inc
 
+FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
+
 SRC_URI = "https://wpewebkit.org/releases/${PN}-${PV}.tar.xz"
+SRC_URI += "file://PKG_CONFIG_SYSROOT_DIR_for_wayland_scanner.patch"
 SRC_URI[md5sum] = "74e1b2fc2bc19933b17ff4f8435f67cd"
 SRC_URI[sha256sum] = "b1bb261273772af8f7d96d94989fc2ed0445ec06c7eb21f47a1b94e52422ddd5"
 

--- a/recipes-browser/wpebackend-fdo/wpebackend-fdo_git.bb
+++ b/recipes-browser/wpebackend-fdo/wpebackend-fdo_git.bb
@@ -1,5 +1,7 @@
 require wpebackend-fdo.inc
 
+FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
+
 DEFAULT_PREFERENCE = "-1"
 PV = "1.2.0~git"
 
@@ -11,6 +13,7 @@ PV = "1.2.0~git"
 
 SRCREV = "${AUTOREV}"
 SRC_URI = "git://github.com/Igalia/WPEBackend-fdo.git;protocol=https;branch=master"
+SRC_URI += "file://PKG_CONFIG_SYSROOT_DIR_for_wayland_scanner.patch"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
WIP Fix cmake to use the wayland-scanner from sysroot-native (fix: #103)