### PR TITLE
cog: Don't build bleeding edge version by default

### DIFF
--- a/recipes-browser/cog/cog_git.bb
+++ b/recipes-browser/cog/cog_git.bb
@@ -1,5 +1,7 @@
 require cog.inc
 
+DEFAULT_PREFERENCE = "-1"
+
 PV = "git${AUTOREV}"
 SRCREV = "${AUTOREV}"
 SRC_URI = " git://github.com/Igalia/cog.git;protocol=https;branch=master"


### PR DESCRIPTION
Building the bleeding edge version of cog by default is problematic for
creating stable builds. Prefer the stable released versions instead.