### PR TITLE
cog: required wayland dependencies when fdo

### DIFF
--- a/recipes-browser/cog/cog.inc
+++ b/recipes-browser/cog/cog.inc
@@ -12,7 +12,12 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=bf1229cd7425b302d60cdb641b0ce5fb"
 # Depend on wpewebkit unless the webkitgtk packageconfig option is selected.
 DEPENDS = " \
             ${@bb.utils.contains('PACKAGECONFIG', 'webkitgtk', 'webkitgtk', 'wpewebkit', d)} \
+            ${@bb.utils.contains('PACKAGECONFIG', 'fdo', 'wayland', '', d)} \
             libsoup-2.4 glib-2.0 wayland-native wayland-protocols \
+            "
+
+DEPENDS_append_class-target = " \
+            ${@bb.utils.contains('PACKAGECONFIG', 'fdo', 'wayland-native', '', d)} \
             "
 
 # At run-time cog package should depend on virtual/wpebackend unless webkitgtk+ is enabled.


### PR DESCRIPTION
cog depends on wayland and wayland-native when is built with FDO