### PR TITLE
wpewebkit: Add unified-builds PACKAGECONFIG

### DIFF
--- a/recipes-browser/wpewebkit/wpewebkit.inc
+++ b/recipes-browser/wpewebkit/wpewebkit.inc
@@ -19,7 +19,7 @@ CCACHE_DISABLE[unexport] = "1"
 
 TOOLCHAIN = "gcc"
 
-PACKAGECONFIG ??= "fetchapi indexeddb mediasource video webaudio webcrypto woff2 gst_gl remote-inspector openjpeg"
+PACKAGECONFIG ??= "fetchapi indexeddb mediasource video webaudio webcrypto woff2 gst_gl remote-inspector openjpeg unified-builds"
 
 # WPE features
 PACKAGECONFIG[bubblewrap] = "-DENABLE_BUBBLEWRAP_SANDBOX=ON,-DENABLE_BUBBLEWRAP_SANDBOX=OFF,bubblewrap xdg-dbus-proxy bubblewrap-native xdg-dbus-proxy-native libseccomp"
@@ -43,6 +43,8 @@ PACKAGECONFIG[remote-inspector] = "-DENABLE_REMOTE_INSPECTOR=ON,-DENABLE_REMOTE_
 PACKAGECONFIG[webrtc] = "-DENABLE_WEB_RTC=ON,-DENABLE_WEB_RTC=OFF,libvpx libevent libopus"
 PACKAGECONFIG[qtwpe] = "-DENABLE_WPE_QT_API=ON,-DENABLE_WPE_QT_API=OFF,qtbase-native qtbase qtdeclarative qtquickcontrols2 libepoxy wpebackend-fdo"
 PACKAGECONFIG[openjpeg] = "-DUSE_OPENJPEG=ON,-DUSE_OPENJPEG=OFF,openjpeg"
+PACKAGECONFIG[unified-builds] = "-DENABLE_UNIFIED_BUILDS=ON,-DENABLE_UNIFIED_BUILDS=OFF,"
+
 
 EXTRA_OECMAKE = " -DPORT=WPE -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_C_COMPILER_LAUNCHER=ccache \

--- a/recipes-browser/wpewebkit/wpewebkit_trunk.bb
+++ b/recipes-browser/wpewebkit/wpewebkit_trunk.bb
@@ -3,7 +3,7 @@ require wpewebkit.inc
 DEFAULT_PREFERENCE = "-1"
 
 SVNBRANCH = "trunk"
-SVNREV ?= "243435"
+SVNREV ?= "244225"
 
 # To enable this recipe set on local.conf
 # PREFERRED_VERSION_wpewebkit = "1.trunk%"


### PR DESCRIPTION
Add ENABLE_UNIFIED_BUILDS option to cmake ports is available since r239561 in WebKit. WebKit 2.24 begins in 241291 so this cmake flag is available for WebKit 2.24 and higher.

  * git-svn-id: http://svn.webkit.org/repository/webkit/trunk@239561
  * git-svn-id: http://svn.webkit.org/repository/webkit/trunk@241291

wpewebkit: bump trunk version (r244225)

    WebKit should build successfully even with -DENABLE_UNIFIED_BUILDS=OFF
    https://bugs.webkit.org/show_bug.cgi?id=196845