### PR TITLE
wpewebkit: bumping up WPE WebKit to 2.26.2

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -49,6 +49,18 @@ warrior-wandboard-mesa-weston-wpe-2.24:
     - bitbake $BITBAKE_TARGET
     - rm -rf tmp
 
+warrior-wandboard-mesa-weston-wpe-2.26:
+  tags:
+    - meta-webkit
+  variables:
+    MANIFEST: manifest-warrior.xml
+    # setup-environment targetname machine distro bblayers presets --update-config
+    SOURCE: wandboard-mesa-wpe-2.26 wandboard-mesa browsers default mesa-wpe-2_26 --update-config
+    BITBAKE_TARGET: wpewebkit
+  script:
+    - bitbake $BITBAKE_TARGET
+    - rm -rf tmp
+
 warrior-wandboard-mesa-weston-wpe-trunk:
   allow_failure: true
   tags:

--- a/recipes-browser/wpewebkit/wpewebkit_2.26.2.bb
+++ b/recipes-browser/wpewebkit/wpewebkit_2.26.2.bb
@@ -2,8 +2,8 @@ require wpewebkit.inc
 
 FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 SRC_URI = "https://wpewebkit.org/releases/${PN}-${PV}.tar.xz"
-SRC_URI[md5sum] = "bec094fe878e03f42de751cbaf0b3e99"
-SRC_URI[sha256sum] = "d1ae85dffb5bfc106c5ac6d5e73a3dfe3cb2c1df1f18c16103e1dc744cd4ac14"
+SRC_URI[md5sum] = "057cc2647231e90c8197873df9a9f54c"
+SRC_URI[sha256sum] = "dd4fce390f1721d8d6d017fa712adb990f7230bde84a1b7d27327bd589053fdd"
 
 DEPENDS += " libwpe"
 RCONFLICTS_${PN} = "libwpe (< 1.2) wpebackend-fdo (< 1.2)"


### PR DESCRIPTION
* Bumping up WPE WebKit to 2.26.2:

  - Improve performance of querying system fallback fonts.
  - Don't use prgname in dbus-proxy socket path.
  - Fix thread-safety issues in image decoders.
  - Fix the build with WebDriver disabled.
  - Fix several crashes and rendering issues.
  - Ref: https://lists.webkit.org/pipermail/webkit-wpe/2019-November/000287.html

* Added missing CI task for 2.26.X