### PR TITLE
wpewebkit: Fix ccache usage

### DIFF
--- a/recipes-browser/wpewebkit/wpewebkit.inc
+++ b/recipes-browser/wpewebkit/wpewebkit.inc
@@ -47,11 +47,7 @@ PACKAGECONFIG[openjpeg] = "-DUSE_OPENJPEG=ON,-DUSE_OPENJPEG=OFF,openjpeg"
 PACKAGECONFIG[unified-builds] = "-DENABLE_UNIFIED_BUILDS=ON,-DENABLE_UNIFIED_BUILDS=OFF,"
 
 
-EXTRA_OECMAKE = " -DPORT=WPE -DCMAKE_BUILD_TYPE=Release \
-    -DCMAKE_C_COMPILER_LAUNCHER=ccache \
-    -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-    -G Ninja \
-"
+EXTRA_OECMAKE = " -DPORT=WPE -DCMAKE_BUILD_TYPE=Release -G Ninja"
 
 # If SSE code compiles, assume it runs successfully (it can't actually run
 # because of cross compiling)


### PR DESCRIPTION
oe-core will correctly configure cmake to use ccache based on the CCACHE
bitbake variable, so don't set it explicitly in the wpewebkit recipe.
Setting it explicitly causes issues if a user doesn't want to use ccache
for some reason (for example, if they are using icecream instead).

If using ccache for this specific recipe is desired, one can set the
following in local.conf:

 CCACHE_pn-wpewebkit = "ccache"

Signed-off-by: Joshua Watt <Joshua.Watt@garmin.com>