### PR TITLE
wpewebkit: Do not use gold linker on mips

### DIFF
--- a/recipes-browser/wpewebkit/wpewebkit.inc
+++ b/recipes-browser/wpewebkit/wpewebkit.inc
@@ -53,6 +53,9 @@ EXTRA_OECMAKE = " -DPORT=WPE -DCMAKE_BUILD_TYPE=Release -G Ninja"
 # If SSE code compiles, assume it runs successfully (it can't actually run
 # because of cross compiling)
 EXTRA_OECMAKE_append_x86 = " -DHAVE_SSE2_EXTENSIONS_EXITCODE=0"
+# mips/gold does not yet implement
+# error: .gnu.hash is incompatible with the MIPS ABI
+EXTRA_OECMAKE_append_mipsarch = " -DUSE_LD_GOLD=OFF "
 
 FULL_OPTIMIZATION_remove = "-g"
 


### PR DESCRIPTION
mips binutils started to support .gnu_hash but gold linker is not there yet

Signed-off-by: Khem Raj <raj.khem@gmail.com>