### PR TITLE
bubblewrap,xdg-dbus-proxy: Update SRC_URI to change BPN instead of PN

### DIFF
--- a/recipes-flatpak/bubblewrap/bubblewrap_0.3.1.bb
+++ b/recipes-flatpak/bubblewrap/bubblewrap_0.3.1.bb
@@ -5,7 +5,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=5f30f0716dfdd0d91eb439ebec522ec2"
 
 DEPENDS = "libcap"
 
-SRC_URI = "https://github.com/projectatomic/${PN}/releases/download/v${PV}/${BPN}-${PV}.tar.xz"
+SRC_URI = "https://github.com/projectatomic/${BPN}/releases/download/v${PV}/${BP}.tar.xz"
 SRC_URI[md5sum] = "c34034985e80bdea39aaaaa4bcb92c64"
 SRC_URI[sha256sum] = "deca6b608c54df4be0669b8bb6d254858924588e9f86e116eb04656a3b6d4bf8"
 

--- a/recipes-flatpak/xdg-dbus-proxy/xdg-dbus-proxy_0.1.0.bb
+++ b/recipes-flatpak/xdg-dbus-proxy/xdg-dbus-proxy_0.1.0.bb
@@ -2,7 +2,7 @@ HOMEPAGE = "https://github.com/flatpak/xdg-dbus-proxy"
 LICENSE = "LGPLv2.1"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/LGPL-2.1;md5=1a6d268fd218675ffea8be556788b780"
 
-SRC_URI = "https://github.com/flatpak/${PN}/releases/download/${PV}/${BPN}-${PV}.tar.xz"
+SRC_URI = "https://github.com/flatpak/${BPN}/releases/download/${PV}/${BP}.tar.xz"
 SRC_URI[md5sum] = "26cc219cf9020ee20fc796427bf4beef"
 SRC_URI[sha256sum] = "9eefd30fe66940c8daf0e8ce6479307694814edb8b636caeb5aa6d6a46a4bc14"
 


### PR DESCRIPTION
Fixes
ERROR: QA Issue: bubblewrap: SRC_URI uses PN not BPN [src-uri-bad]

Signed-off-by: Khem Raj <raj.khem@gmail.com>