### PR TITLE
Fix the meta-webkit layer for old poky releases oder than dunfell.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,13 +29,6 @@ The meta-security dependency is necessary to enable web process sandbox for WPE.
 If meta-qt5 is present, this layer will provide an opt-in Qt5 API as an
 alternative to other Qt5 web-engines such as QtWebKit and QtWebEngine.
 
-For Yocto releases prior to thud we highly recommend users to add the meta-gstreamer1.0 layer to their distro:
-
-    URI: https://github.com/OSSystems/meta-gstreamer1.0.git
-    branch: rocko or sumo
-    revision: HEAD
-
-
 Building the WPE engine or WebKitGTK+
 =====================================
 

--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -16,4 +16,4 @@ BBFILE_PRIORITY_webkit = "7"
 # do not error out on bbappends for missing recipes
 BB_DANGLINGAPPENDS_WARNONLY = "true"
 
-LAYERSERIES_COMPAT_webkit = "rocko sumo thud warrior zeus dunfell"
+LAYERSERIES_COMPAT_webkit = "sumo thud warrior zeus dunfell"

--- a/recipes-benchmark/browserperfrunner/browserperfrunner_git.bb
+++ b/recipes-benchmark/browserperfrunner/browserperfrunner_git.bb
@@ -22,13 +22,13 @@ RDEPENDS_${PN} = " curl make patch perl procps psmisc python python-misc \
 # This recipe still requires python2.
 # So on Yocto dunfell and later its needed to use meta-python2
 # Port to python3 tracked at https://github.com/Igalia/browserperfrunner/issues/3
-inherit ${@bb.utils.contains_any("LAYERSERIES_CORENAMES", "zeus warrior thud sumo rocko pyro", \
+inherit ${@bb.utils.contains_any("LAYERSERIES_CORENAMES", "zeus warrior thud sumo", \
         "python-dir", \
         bb.utils.contains("BBFILE_COLLECTIONS", "meta-python2", "python-dir", "", d), \
         d)}
 
 python() {
-    if d.getVar('LAYERSERIES_CORENAMES') not in ["zeus", "warrior", "thud", "sumo", "rocko", "pyro"]:
+    if d.getVar('LAYERSERIES_CORENAMES') not in ["zeus", "warrior", "thud", "sumo"]:
         if "meta-python2" not in d.getVar("BBFILE_COLLECTIONS").split():
             raise bb.parse.SkipRecipe("Requires meta-python2 to be present.")
 }

--- a/recipes-browser/images/core-image-wpe-crosscompilation.bb
+++ b/recipes-browser/images/core-image-wpe-crosscompilation.bb
@@ -5,7 +5,12 @@ SUMMARY = "WPE cross-compilation image with wpebackend-fdo. \
 
 LICENSE = "BSD"
 
-inherit core-image distro_features_check
+inherit core-image
+
+# distro_features_check is going to be removed after dunfell
+# ref: https://git.yoctoproject.org/cgit/cgit.cgi/poky/commit/meta/classes/features_check.bbclass?h=master-next&id=9702544b3e75d761d86cae7e8b36f3f2625b68ce
+#   Temporarily support the old class name with a warning about future deprecation.
+inherit ${@bb.utils.contains_any("LAYERSERIES_CORENAMES", 'zeus warrior thud sumo', 'distro_features_check', 'features_check', d)}
 
 REQUIRED_DISTRO_FEATURES = "wayland"
 

--- a/recipes-browser/webkitgtk/webkitgtk_2.28.0.bb
+++ b/recipes-browser/webkitgtk/webkitgtk_2.28.0.bb
@@ -25,7 +25,12 @@ RRECOMMENDS_${PN} = "${PN}-bin \
                      "
 RRECOMMENDS_${PN}-bin = "adwaita-icon-theme librsvg-gtk"
 
-inherit cmake lib_package pkgconfig perlnative python3native features_check
+inherit cmake lib_package pkgconfig perlnative python3native
+
+# distro_features_check is going to be removed after dunfell
+# ref: https://git.yoctoproject.org/cgit/cgit.cgi/poky/commit/meta/classes/features_check.bbclass?h=master-next&id=9702544b3e75d761d86cae7e8b36f3f2625b68ce
+#   Temporarily support the old class name with a warning about future deprecation.
+inherit ${@bb.utils.contains_any("LAYERSERIES_CORENAMES", 'zeus warrior thud sumo', 'distro_features_check', 'features_check', d)}
 
 S = "${WORKDIR}/webkitgtk-${PV}/"
 


### PR DESCRIPTION
Added a conditional inherit of distro_features_check for old releases. The distro_features_check is going to be removed after dunfell. 
    
Ref:
    https://git.yoctoproject.org/cgit/cgit.cgi/poky/commit/meta/classes/features_check.bbclass?h=master-next&id=9702544b3e75d761d86cae7e8b36f3f2625b68ce
    
Also, updated the layer compatibility to: `warrior zeus dunfell`
