### PR TITLE
wpewebkit: Do not enable qtwpe packageconfig automatically with meta-qt5

### DIFF
--- a/dynamic-layers/qt5-layer/recipes-browser/wpewebkit/wpewebkit_%.bbappend
+++ b/dynamic-layers/qt5-layer/recipes-browser/wpewebkit/wpewebkit_%.bbappend
@@ -1,3 +1,0 @@
-# Enable QT bindings for WPE when meta-qt5 is in layer mix
-#
-PACKAGECONFIG_append = " qtwpe"

--- a/recipes-browser/wpewebkit/wpewebkit.inc
+++ b/recipes-browser/wpewebkit/wpewebkit.inc
@@ -13,7 +13,7 @@ DEPENDS = " \
 "
 
 inherit cmake pkgconfig perlnative python3native
-inherit ${@'cmake_qt5' if 'qt5-layer' in d.getVar('BBFILE_COLLECTIONS').split() else ''}
+inherit ${@'cmake_qt5' if 'qtwpe' in d.getVar('PACKAGECONFIG').split() else ''}
 
 CCACHE_DISABLE[unexport] = "1"
 


### PR DESCRIPTION
Leave this choice to user, since meta-qt5 maybe includes in layermix for
other reasons.

Signed-off-by: Khem Raj <raj.khem@gmail.com>