### PR TITLE
wpebackend-fdo: wpebackend-fdo >= 1.8 depends on libepoxy

### DIFF
--- a/recipes-browser/wpebackend-fdo/wpebackend-fdo_1.6.0.bb
+++ b/recipes-browser/wpebackend-fdo/wpebackend-fdo_1.6.0.bb
@@ -5,6 +5,10 @@ SRC_URI[sha256sum] = "7f5bd7b9d8f97b1655f4dcd39fad92719d0fb3985b251da5802df13aaa
 
 BBCLASSEXTEND += "devupstream:target"
 
+# Those dependencies shall be promoted to the next wpebackend-fdo 1.8.X releases
+# converving the older dependencies for packages previous to this version.
+DEPENDS_class-devupstream = "glib-2.0 libxkbcommon wayland libepoxy"
+
 SRC_URI_class-devupstream = "git://github.com/Igalia/WPEBackend-fdo.git;protocol=https;branch=master"
 SRCREV_class-devupstream = "5b4fa3cf160c957589a06d3b99589e53cccb0ee1"
 


### PR DESCRIPTION
* Use libepoxy for EGL operations

```
Instead of relying on EGL headers and library provided at compile-time, use libepoxy to push that necessity to runtime.

The CMake integration follows the new 'imported' model. Instead of manually parsing the EGL extension list to detect present extensions, we can rely on the epoxy_has_egl_extension() function.
```

Package reference:
https://github.com/Igalia/WPEBackend-fdo/commit/69d8aa3c40f71994a6e41d5769807a7bbf6725dc