### PR TITLE
wpewebkit: Fix linker errors on riscv64

### DIFF
--- a/recipes-browser/wpewebkit/wpewebkit.inc
+++ b/recipes-browser/wpewebkit/wpewebkit.inc
@@ -57,6 +57,8 @@ EXTRA_OECMAKE_append_x86 = " -DHAVE_SSE2_EXTENSIONS_EXITCODE=0"
 # error: .gnu.hash is incompatible with the MIPS ABI
 EXTRA_OECMAKE_append_mipsarch = " -DUSE_LD_GOLD=OFF "
 
+LDFLAGS_append_riscv64 = " -pthread"
+
 FULL_OPTIMIZATION_remove = "-g"
 
 LEAD_SONAME = "libWPEWebKit.so"


### PR DESCRIPTION
This fixes linker errors eg.
Source/WTF/wtf/CMakeFiles/WTF.dir/Assertions.cpp.o:Assertions.cpp:(.text+
0x4c8): more undefined references to `__atomic_compare_exchange_1' follow
| collect2: error: ld returned 1 exit status
| [2268/4244] Linking CXX executable bin/LLIntOffsetsExtractor
| ninja: build stopped: subcommand failed.

Signed-off-by: Khem Raj <raj.khem@gmail.com>