### PR TITLE
wpewebkit: Fix build with musl

### DIFF
--- a/recipes-browser/webkitgtk/webkitgtk/musl.patch
+++ b/recipes-browser/webkitgtk/webkitgtk/musl.patch
@@ -1,0 +1,112 @@
+--- a/Source/JavaScriptCore/runtime/MachineContext.h
++++ b/Source/JavaScriptCore/runtime/MachineContext.h
+@@ -196,7 +196,7 @@ static inline void*& stackPointerImpl(mc
+ #error Unknown Architecture
+ #endif
+ 
+-#elif OS(FUCHSIA) || defined(__GLIBC__) || defined(__BIONIC__)
++#elif OS(FUCHSIA) || OS(LINUX)
+ 
+ #if CPU(X86)
+     return reinterpret_cast<void*&>((uintptr_t&) machineContext.gregs[REG_ESP]);
+@@ -347,7 +347,7 @@ static inline void*& framePointerImpl(mc
+ #error Unknown Architecture
+ #endif
+ 
+-#elif OS(FUCHSIA) || defined(__GLIBC__) || defined(__BIONIC__)
++#elif OS(FUCHSIA) || OS(LINUX)
+ 
+ // The following sequence depends on glibc's sys/ucontext.h.
+ #if CPU(X86)
+@@ -498,7 +498,7 @@ static inline void*& instructionPointerI
+ #error Unknown Architecture
+ #endif
+ 
+-#elif OS(FUCHSIA) || defined(__GLIBC__) || defined(__BIONIC__)
++#elif OS(FUCHSIA) || OS(LINUX)
+ 
+ // The following sequence depends on glibc's sys/ucontext.h.
+ #if CPU(X86)
+@@ -656,7 +656,7 @@ inline void*& argumentPointer<1>(mcontex
+ #error Unknown Architecture
+ #endif
+ 
+-#elif OS(FUCHSIA) || defined(__GLIBC__) || defined(__BIONIC__)
++#elif OS(FUCHSIA) || OS(LINUX)
+ 
+ // The following sequence depends on glibc's sys/ucontext.h.
+ #if CPU(X86)
+@@ -773,7 +773,7 @@ inline void*& llintInstructionPointer(mc
+ #error Unknown Architecture
+ #endif
+ 
+-#elif OS(FUCHSIA) || defined(__GLIBC__) || defined(__BIONIC__)
++#elif OS(FUCHSIA) || OS(LINUX)
+ 
+ // The following sequence depends on glibc's sys/ucontext.h.
+ #if CPU(X86)
+--- a/Source/JavaScriptCore/runtime/OptionsList.h
++++ b/Source/JavaScriptCore/runtime/OptionsList.h
+@@ -71,6 +71,18 @@ JS_EXPORT_PRIVATE bool canUseJITCage();
+ // On instantiation of the first VM instance, the Options will be write protected
+ // and cannot be modified thereafter.
+ 
++#if OS(LINUX) && !defined(__BIONIC__) && !defined(__GLIBC__)
++// non-glibc/non-android options on linux ( musl )
++constexpr unsigned jscMaxPerThreadStack = 128 * KB;
++constexpr unsigned jscSoftReservedZoneSize = 32 * KB;
++constexpr unsigned jscReservedZoneSize = 16 * KB;
++#else
++// default
++constexpr unsigned jscMaxPerThreadStack = 5 * MB;
++constexpr unsigned jscSoftReservedZoneSize = 128 * KB;
++constexpr unsigned jscReservedZoneSize = 64 * KB;
++#endif
++
+ #define FOR_EACH_JSC_OPTION(v)                                          \
+     v(Bool, useKernTCSM, defaultTCSMValue(), Normal, "Note: this needs to go before other options since they depend on this value.") \
+     v(Bool, validateOptions, false, Normal, "crashes if mis-typed JSC options were passed to the VM") \
+@@ -86,9 +98,9 @@ JS_EXPORT_PRIVATE bool canUseJITCage();
+     \
+     v(Bool, reportMustSucceedExecutableAllocations, false, Normal, nullptr) \
+     \
+-    v(Unsigned, maxPerThreadStackUsage, 5 * MB, Normal, "Max allowed stack usage by the VM") \
+-    v(Unsigned, softReservedZoneSize, 128 * KB, Normal, "A buffer greater than reservedZoneSize that reserves space for stringifying exceptions.") \
+-    v(Unsigned, reservedZoneSize, 64 * KB, Normal, "The amount of stack space we guarantee to our clients (and to interal VM code that does not call out to clients).") \
++    v(Unsigned, maxPerThreadStackUsage, jscMaxPerThreadStack, Normal, "Max allowed stack usage by the VM") \
++    v(Unsigned, softReservedZoneSize, jscSoftReservedZoneSize, Normal, "A buffer greater than reservedZoneSize that reserves space for stringifying exceptions.") \
++    v(Unsigned, reservedZoneSize, jscReservedZoneSize, Normal, "The amount of stack space we guarantee to our clients (and to interal VM code that does not call out to clients).") \
+     \
+     v(Bool, crashOnDisallowedVMEntry, ASSERT_ENABLED, Normal, "Forces a crash if we attempt to enter the VM when disallowed") \
+     v(Bool, crashIfCantAllocateJITMemory, false, Normal, nullptr) \
+@@ -608,7 +620,7 @@ public:
+     bool init(const char*);
+     bool isInRange(unsigned);
+     const char* rangeString() const { return (m_state > InitError) ? m_rangeString : s_nullRangeStr; }
+-    
++
+     void dump(PrintStream& out) const;
+ 
+ private:
+--- a/Source/WTF/wtf/PlatformHave.h
++++ b/Source/WTF/wtf/PlatformHave.h
+@@ -206,7 +206,7 @@
+ #define HAVE_HOSTED_CORE_ANIMATION 1
+ #endif
+ 
+-#if OS(DARWIN) || OS(FUCHSIA) || ((OS(FREEBSD) || defined(__GLIBC__) || defined(__BIONIC__)) && (CPU(X86) || CPU(X86_64) || CPU(ARM) || CPU(ARM64) || CPU(MIPS)))
++#if OS(DARWIN) || OS(FUCHSIA) || ((OS(FREEBSD) || OS(LINUX)) && (CPU(X86) || CPU(X86_64) || CPU(ARM) || CPU(ARM64) || CPU(MIPS)))
+ #define HAVE_MACHINE_CONTEXT 1
+ #endif
+ 
+--- a/Source/WTF/wtf/Threading.cpp
++++ b/Source/WTF/wtf/Threading.cpp
+@@ -52,6 +52,8 @@ static Optional<size_t> stackSize(Thread
+ #elif OS(DARWIN) && ASAN_ENABLED
+     if (threadType == ThreadType::Compiler)
+         return 1 * MB; // ASan needs more stack space (especially on Debug builds).
++#elif OS(LINUX) && !defined(__BIONIC__) && !defined(__GLIBC__) // MUSL default thread stack size.
++        return 128 * KB;
+ #else
+     UNUSED_PARAM(threadType);
+ #endif

--- a/recipes-browser/webkitgtk/webkitgtk_2.32.0.bb
+++ b/recipes-browser/webkitgtk/webkitgtk_2.32.0.bb
@@ -12,7 +12,9 @@ DEPENDS = "zlib libsoup-2.4 curl libxml2 cairo libxslt libidn gnutls \
            libwebp harfbuzz glib-2.0 gettext-native glib-2.0-native \
            sqlite3 libgcrypt"
 
-SRC_URI = "https://www.webkitgtk.org/releases/webkitgtk-${PV}.tar.xz"
+SRC_URI = "https://www.webkitgtk.org/releases/webkitgtk-${PV}.tar.xz \
+           file://musl.patch \
+           "
 SRC_URI[sha256sum] = "9d7df4dae9ada2394257565acc2a68ace9308c4c61c3fcc00111dc1f11076bf0"
 
 RRECOMMENDS_${PN} = "${PN}-bin \

--- a/recipes-browser/wpewebkit/wpewebkit/musl.patch
+++ b/recipes-browser/wpewebkit/wpewebkit/musl.patch
@@ -1,0 +1,112 @@
+--- a/Source/JavaScriptCore/runtime/MachineContext.h
++++ b/Source/JavaScriptCore/runtime/MachineContext.h
+@@ -196,7 +196,7 @@ static inline void*& stackPointerImpl(mc
+ #error Unknown Architecture
+ #endif
+ 
+-#elif OS(FUCHSIA) || defined(__GLIBC__) || defined(__BIONIC__)
++#elif OS(FUCHSIA) || OS(LINUX)
+ 
+ #if CPU(X86)
+     return reinterpret_cast<void*&>((uintptr_t&) machineContext.gregs[REG_ESP]);
+@@ -347,7 +347,7 @@ static inline void*& framePointerImpl(mc
+ #error Unknown Architecture
+ #endif
+ 
+-#elif OS(FUCHSIA) || defined(__GLIBC__) || defined(__BIONIC__)
++#elif OS(FUCHSIA) || OS(LINUX)
+ 
+ // The following sequence depends on glibc's sys/ucontext.h.
+ #if CPU(X86)
+@@ -498,7 +498,7 @@ static inline void*& instructionPointerI
+ #error Unknown Architecture
+ #endif
+ 
+-#elif OS(FUCHSIA) || defined(__GLIBC__) || defined(__BIONIC__)
++#elif OS(FUCHSIA) || OS(LINUX)
+ 
+ // The following sequence depends on glibc's sys/ucontext.h.
+ #if CPU(X86)
+@@ -656,7 +656,7 @@ inline void*& argumentPointer<1>(mcontex
+ #error Unknown Architecture
+ #endif
+ 
+-#elif OS(FUCHSIA) || defined(__GLIBC__) || defined(__BIONIC__)
++#elif OS(FUCHSIA) || OS(LINUX)
+ 
+ // The following sequence depends on glibc's sys/ucontext.h.
+ #if CPU(X86)
+@@ -773,7 +773,7 @@ inline void*& llintInstructionPointer(mc
+ #error Unknown Architecture
+ #endif
+ 
+-#elif OS(FUCHSIA) || defined(__GLIBC__) || defined(__BIONIC__)
++#elif OS(FUCHSIA) || OS(LINUX)
+ 
+ // The following sequence depends on glibc's sys/ucontext.h.
+ #if CPU(X86)
+--- a/Source/JavaScriptCore/runtime/OptionsList.h
++++ b/Source/JavaScriptCore/runtime/OptionsList.h
+@@ -71,6 +71,18 @@ JS_EXPORT_PRIVATE bool canUseJITCage();
+ // On instantiation of the first VM instance, the Options will be write protected
+ // and cannot be modified thereafter.
+ 
++#if OS(LINUX) && !defined(__BIONIC__) && !defined(__GLIBC__)
++// non-glibc/non-android options on linux ( musl )
++constexpr unsigned jscMaxPerThreadStack = 128 * KB;
++constexpr unsigned jscSoftReservedZoneSize = 32 * KB;
++constexpr unsigned jscReservedZoneSize = 16 * KB;
++#else
++// default
++constexpr unsigned jscMaxPerThreadStack = 5 * MB;
++constexpr unsigned jscSoftReservedZoneSize = 128 * KB;
++constexpr unsigned jscReservedZoneSize = 64 * KB;
++#endif
++
+ #define FOR_EACH_JSC_OPTION(v)                                          \
+     v(Bool, useKernTCSM, defaultTCSMValue(), Normal, "Note: this needs to go before other options since they depend on this value.") \
+     v(Bool, validateOptions, false, Normal, "crashes if mis-typed JSC options were passed to the VM") \
+@@ -86,9 +98,9 @@ JS_EXPORT_PRIVATE bool canUseJITCage();
+     \
+     v(Bool, reportMustSucceedExecutableAllocations, false, Normal, nullptr) \
+     \
+-    v(Unsigned, maxPerThreadStackUsage, 5 * MB, Normal, "Max allowed stack usage by the VM") \
+-    v(Unsigned, softReservedZoneSize, 128 * KB, Normal, "A buffer greater than reservedZoneSize that reserves space for stringifying exceptions.") \
+-    v(Unsigned, reservedZoneSize, 64 * KB, Normal, "The amount of stack space we guarantee to our clients (and to interal VM code that does not call out to clients).") \
++    v(Unsigned, maxPerThreadStackUsage, jscMaxPerThreadStack, Normal, "Max allowed stack usage by the VM") \
++    v(Unsigned, softReservedZoneSize, jscSoftReservedZoneSize, Normal, "A buffer greater than reservedZoneSize that reserves space for stringifying exceptions.") \
++    v(Unsigned, reservedZoneSize, jscReservedZoneSize, Normal, "The amount of stack space we guarantee to our clients (and to interal VM code that does not call out to clients).") \
+     \
+     v(Bool, crashOnDisallowedVMEntry, ASSERT_ENABLED, Normal, "Forces a crash if we attempt to enter the VM when disallowed") \
+     v(Bool, crashIfCantAllocateJITMemory, false, Normal, nullptr) \
+@@ -608,7 +620,7 @@ public:
+     bool init(const char*);
+     bool isInRange(unsigned);
+     const char* rangeString() const { return (m_state > InitError) ? m_rangeString : s_nullRangeStr; }
+-    
++
+     void dump(PrintStream& out) const;
+ 
+ private:
+--- a/Source/WTF/wtf/PlatformHave.h
++++ b/Source/WTF/wtf/PlatformHave.h
+@@ -206,7 +206,7 @@
+ #define HAVE_HOSTED_CORE_ANIMATION 1
+ #endif
+ 
+-#if OS(DARWIN) || OS(FUCHSIA) || ((OS(FREEBSD) || defined(__GLIBC__) || defined(__BIONIC__)) && (CPU(X86) || CPU(X86_64) || CPU(ARM) || CPU(ARM64) || CPU(MIPS)))
++#if OS(DARWIN) || OS(FUCHSIA) || ((OS(FREEBSD) || OS(LINUX)) && (CPU(X86) || CPU(X86_64) || CPU(ARM) || CPU(ARM64) || CPU(MIPS)))
+ #define HAVE_MACHINE_CONTEXT 1
+ #endif
+ 
+--- a/Source/WTF/wtf/Threading.cpp
++++ b/Source/WTF/wtf/Threading.cpp
+@@ -52,6 +52,8 @@ static Optional<size_t> stackSize(Thread
+ #elif OS(DARWIN) && ASAN_ENABLED
+     if (threadType == ThreadType::Compiler)
+         return 1 * MB; // ASan needs more stack space (especially on Debug builds).
++#elif OS(LINUX) && !defined(__BIONIC__) && !defined(__GLIBC__) // MUSL default thread stack size.
++        return 128 * KB;
+ #else
+     UNUSED_PARAM(threadType);
+ #endif

--- a/recipes-browser/wpewebkit/wpewebkit_2.32.0.bb
+++ b/recipes-browser/wpewebkit/wpewebkit_2.32.0.bb
@@ -4,6 +4,7 @@ require conf/include/devupstream.inc
 FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 SRC_URI = "\
     https://wpewebkit.org/releases/${BPN}-${PV}.tar.xz \
+    file://musl.patch \
 "
 
 SRC_URI[sha256sum] = "6cfb18af9a180eeffffcaf34fea68d867ee59f633d811ced92bbead2d184b6ea"


### PR DESCRIPTION
Adjust jsc maximum stack limits, so we can avoid stack overflows while
executing javascript code

Signed-off-by: Khem Raj <raj.khem@gmail.com>