### PR TITLE
wpewebkit: Do not pin to gcc-only compiler

### DIFF
--- a/recipes-browser/wpewebkit/wpewebkit.inc
+++ b/recipes-browser/wpewebkit/wpewebkit.inc
@@ -17,8 +17,6 @@ inherit ${@'cmake_qt5' if 'qt5-layer' in d.getVar('BBFILE_COLLECTIONS').split() 
 
 CCACHE_DISABLE[unexport] = "1"
 
-TOOLCHAIN = "gcc"
-
 PACKAGECONFIG ??= "fetchapi indexeddb mediasource video webaudio webcrypto woff2 gst_gl remote-inspector openjpeg unified-builds"
 
 # WPE features


### PR DESCRIPTION
There were issues with clang-6 but now a days we are using clang-10 in
meta-clang and that can happily compile wpewebkit ( infact faster )

Signed-off-by: Khem Raj <raj.khem@gmail.com>