### PR TITLE
packagegroup-wpewebkit-depends-video: Add libvpx dependency

### DIFF
--- a/recipes-browser/packagegroups/packagegroup-wpewebkit-depends.bb
+++ b/recipes-browser/packagegroups/packagegroup-wpewebkit-depends.bb
@@ -222,6 +222,7 @@ RDEPENDS_packagegroup-wpewebkit-depends-video = " \
     gstreamer1.0-plugins-bad-mpegtsdemux \
     gstreamer1.0-plugins-bad-smoothstreaming \
     gstreamer1.0-plugins-bad-videoparsersbad \
+    libvpx \
 "
 
 RDEPENDS_packagegroup-wpewebkit-depends-extra = " \


### PR DESCRIPTION
... required for `-DENABLE_VIDEO=ON`.

Reference in the upstream Changelog:

```
    2018-04-05  Alejandro G. Castro  <alex@igalia.com>

        [GTK] Add CMake package search for vpx and libevent libraries
        https://bugs.webkit.org/show_bug.cgi?id=184257

        Reviewed by Michael Catanzaro.

        Add new cmake search files for libevent, vpx and alsa-lib, this
        makes a cleaner detection of the libraries.

        * CMakeLists.txt: Use the new cmake find files to detect the
        package and add a better error message when the library is not
        there.
        * Source/cmake/FindAlsaLib.cmake: Added.
        * Source/cmake/FindLibEvent.cmake: Added.
        * Source/cmake/FindVpx.cmake: Added.
```