### PR TITLE
packagegroup-wpewebkit-depends: Separate out libc specific dependencies

### DIFF
--- a/recipes-browser/packagegroups/packagegroup-wpewebkit-depends.bb
+++ b/recipes-browser/packagegroups/packagegroup-wpewebkit-depends.bb
@@ -143,7 +143,7 @@ RDEPENDS_packagegroup-wpewebkit-depends-core = "\
     libgcrypt \
     bubblewrap \
     xdg-dbus-proxy \
-    libseccomp \
+    ${@bb.utils.contains('BBFILE_COLLECTIONS', 'security', 'libseccomp', '', d)} \
     libicudata \
 "
 

--- a/recipes-browser/packagegroups/packagegroup-wpewebkit-depends.bb
+++ b/recipes-browser/packagegroups/packagegroup-wpewebkit-depends.bb
@@ -60,10 +60,7 @@ RDEPENDS_packagegroup-wpewebkit-depends-python = "\
     gmp \
     ncurses \
     openssl \
-    python \
-    python \
-    python-modules \
-    python-misc \
+    ${@bb.utils.contains('BBFILE_COLLECTIONS', 'meta-python2', 'python python-modules python-misc', '', d)} \
     readline \
     zip \
 "
@@ -244,10 +241,7 @@ RDEPENDS_packagegroup-wpewebkit-depends-tests = " \
     curl \
     gdb \
     php \
-    python \
-    python-subprocess32 \
-    python-pygobject \
-    python-psutil \
+    ${@bb.utils.contains('BBFILE_COLLECTIONS', 'meta-python2', 'python python-subprocess32 python-pygobject python-psutil', '', d)} \
     psmisc \
     pulseaudio \
     pulseaudio-misc \

--- a/recipes-browser/packagegroups/packagegroup-wpewebkit-depends.bb
+++ b/recipes-browser/packagegroups/packagegroup-wpewebkit-depends.bb
@@ -88,7 +88,6 @@ RDEPENDS_packagegroup-wpewebkit-depends-core = "\
     cronie \
     diffutils \
     ed \
-    glibc-utils \
     elfutils \
     file \
     findutils \
@@ -96,7 +95,6 @@ RDEPENDS_packagegroup-wpewebkit-depends-core = "\
     gawk \
     grep \
     gzip \
-    localedef \
     make \
     msmtp \
     patch \
@@ -108,7 +106,6 @@ RDEPENDS_packagegroup-wpewebkit-depends-core = "\
     time \
     util-linux \
     xdg-utils \
-    glibc \
     libgcc \
     libpam \
     libxml2 \
@@ -143,7 +140,11 @@ RDEPENDS_packagegroup-wpewebkit-depends-core = "\
     ${@bb.utils.contains('BBFILE_COLLECTIONS', 'security', 'libseccomp', '', d)} \
     libicudata \
 "
-
+RDEPENDS_packagegroup-wpewebkit-depends-core_append_libc-glibc = "\
+    glibc \
+    glibc-utils \
+    localedef \
+"
 RDEPENDS_packagegroup-wpewebkit-depends-desktop = "\
     libxt \
     libxxf86vm \
@@ -172,6 +173,8 @@ RDEPENDS_packagegroup-wpewebkit-depends-runtime-add = "\
     libxml-parser-perl \
     libxml-perl \
     libxml-sax-perl \
+"
+RDEPENDS_packagegroup-wpewebkit-depends-runtime-add_append_libc-glibc = "\
     glibc-localedatas \
     glibc-gconvs \
     glibc-charmaps \


### PR DESCRIPTION
This helps in making sure musl based distros can safely parse recipes
from meta-webkit

Signed-off-by: Khem Raj <raj.khem@gmail.com>