### PR TITLE
wpebackend-fdo: Add virtual/mesa as dependency

### DIFF
--- a/recipes-browser/wpebackend-fdo/wpebackend-fdo.inc
+++ b/recipes-browser/wpebackend-fdo/wpebackend-fdo.inc
@@ -4,7 +4,7 @@ BUGTRACKER = "https://github.com/Igalia/WPEBackend-fdo/issues"
 
 LICENSE = "BSD"
 LIC_FILES_CHKSUM = "file://COPYING;md5=1f62cef2e3645e3e74eb05fd389d7a66"
-DEPENDS = "glib-2.0 libxkbcommon wayland virtual/egl libwpe libepoxy"
+DEPENDS = "glib-2.0 libxkbcommon wayland virtual/egl virtual/mesa libwpe libepoxy"
 DEPENDS_append_class-target = " wayland-native"
 PROVIDES += "virtual/wpebackend"
 RPROVIDES_${PN} += "virtual/wpebackend"


### PR DESCRIPTION
Libs like libwayland-egl should be provided by packages supporting this virtual package (usually mesa but it could be any other). This library is normally used for Wayland apps such Weston for stacked Weston servers and so.

In the top of that, for the case of the wpebackend-fdo makes all the sense this dependency because this package indeed relies on the FDO stack.

Signed-off-by: Pablo Saavedra <psaavedra@igalia.com>