### PR TITLE
webkitgtk: Bump up webkitgtk to 2.30.3

### DIFF
--- a/recipes-browser/webkitgtk/webkitgtk_2.30.3.bb
+++ b/recipes-browser/webkitgtk/webkitgtk_2.30.3.bb
@@ -13,7 +13,7 @@ DEPENDS = "zlib libsoup-2.4 curl libxml2 cairo libxslt libidn gnutls \
            sqlite3 libgcrypt"
 
 SRC_URI = "https://www.webkitgtk.org/releases/webkitgtk-${PV}.tar.xz"
-SRC_URI[sha256sum] = "caf3dbf2d2383072614e34281f2fffb6331faf92f4ecf215f6f6a5a57f755d11"
+SRC_URI[sha256sum] = "6dea14f03916882816f2fed9497a5103fc54b2ab8602ab145ca991e4951e5e7f"
 
 RRECOMMENDS_${PN} = "${PN}-bin \
                      ca-certificates \


### PR DESCRIPTION
Release notes:

* https://webkitgtk.org/2020/11/20/webkitgtk2.30.3-released.html
* https://webkitgtk.org/2020/10/23/webkitgtk2.30.2-released.html
* https://webkitgtk.org/2020/09/21/webkitgtk2.30.1-released.html

Signed-off-by: Pablo Saavedra <psaavedra@igalia.com>