### PR TITLE
packagegroup-wpewebkit-depends-sys-extended: Fix dependencies for gat…

### DIFF
--- a/recipes-browser/packagegroups/packagegroup-wpewebkit-depends.bb
+++ b/recipes-browser/packagegroups/packagegroup-wpewebkit-depends.bb
@@ -31,7 +31,7 @@ RDEPENDS_packagegroup-wpewebkit-depends = "\
 
 RDEPENDS_packagegroup-wpewebkit-depends-sys-extended = "\
     curl \
-    dhcp-client \
+    ${@bb.utils.contains_any('LAYERSERIES_CORENAMES', 'warrior zeus dunfell', 'dhcp-client', 'dhcpcd', d)} \
     hdparm \
     libaio \
     lzo \
@@ -218,7 +218,7 @@ RDEPENDS_packagegroup-wpewebkit-depends-video = " \
     gstreamer1.0-plugins-good-avi \
     gstreamer1.0-plugins-good-deinterlace \
     gstreamer1.0-plugins-good-interleave \
-    gstreamer1.0-plugins-bad-dashdemux \
+    ${@bb.utils.contains_any('LAYERSERIES_CORENAMES', 'warrior zeus dunfell', 'gstreamer1.0-plugins-bad-dashdemux', 'gstreamer1.0-plugins-bad-dash', d)} \
     gstreamer1.0-plugins-bad-mpegtsdemux \
     gstreamer1.0-plugins-bad-smoothstreaming \
     gstreamer1.0-plugins-bad-videoparsersbad \


### PR DESCRIPTION
…esgarth

* Replace dhcp-client with dhcpcd based on this change in poky (gatesgarth):

      Author: Richard Purdie <richard.purdie@linuxfoundation.org>
      Date:   Tue Sep 1 19:20:58 2020 +0100

        build-appliance/packagegroup-core-base-utils: Replace dhcp-client/
        dhcp-server with dhcpcd/kea

        dhcp-client/dhcp-server is obsolete and unmaintained and about to be
        removed, replace it with something which is maintained.

        (From OE-Core rev: 2eae7e6f665ad5a0d734edda6ef5dff5a534eca6)

        Signed-off-by: Richard Purdie <richard.purdie@linuxfoundation.org>

* gstreamer1.0-plugins-bad-dashdemux is now gstreamer1.0-plugins-bad-dash

Unreviewed patch

Signed-off-by: Pablo Saavedra <psaavedra@igalia.com>