### PR TITLE
wpebackend-fdo: Inherit from meson

### DIFF
--- a/recipes-browser/wpebackend-fdo/wpebackend-fdo.inc
+++ b/recipes-browser/wpebackend-fdo/wpebackend-fdo.inc
@@ -9,7 +9,9 @@ DEPENDS_append_class-target = " wayland-native"
 PROVIDES += "virtual/wpebackend"
 RPROVIDES_${PN} += "virtual/wpebackend"
 
-inherit cmake
+# wpebackend-fdo uses meson since (not branched yet)
+#   https://github.com/Igalia/WPEBackend-fdo/commit/9c13d73bcc3726e2290c182d76d67b384f4c1318
+inherit ${@bb.utils.contains("SRCREV", 'INVALID', 'cmake', 'meson', d)}
 
 FILES_SOLIBSDEV = ""
 FILES_${PN} += "${libdir}/libWPEBackend-fdo-*.so"


### PR DESCRIPTION
wpebackend-fdo uses meson since (not branched yet):

Ref:
https://github.com/Igalia/WPEBackend-fdo/commit/9c13d73bcc3726e2290c182d76d67b384f4c1318

Unreviewed patch.