### PR TITLE
wpebackend-fdo: Create wpebackend-fdo_devupstream

### DIFF
--- a/recipes-browser/wpebackend-fdo/wpebackend-fdo.inc
+++ b/recipes-browser/wpebackend-fdo/wpebackend-fdo.inc
@@ -9,10 +9,6 @@ DEPENDS_append_class-target = " wayland-native"
 PROVIDES += "virtual/wpebackend"
 RPROVIDES_${PN} += "virtual/wpebackend"
 
-# wpebackend-fdo uses meson since (not branched yet)
-#   https://github.com/Igalia/WPEBackend-fdo/commit/9c13d73bcc3726e2290c182d76d67b384f4c1318
-inherit ${@bb.utils.contains("SRCREV", 'INVALID', 'cmake', 'meson', d)}
-
 FILES_SOLIBSDEV = ""
 FILES_${PN} += "${libdir}/libWPEBackend-fdo-*.so"
 INSANE_SKIP_${PN} ="dev-so"

--- a/recipes-browser/wpebackend-fdo/wpebackend-fdo_1.6.1.bb
+++ b/recipes-browser/wpebackend-fdo/wpebackend-fdo_1.6.1.bb
@@ -1,5 +1,7 @@
 require wpebackend-fdo.inc
 
+inherit cmake
+
 SRC_URI = "https://wpewebkit.org/releases/${BPN}-${PV}.tar.xz"
 SRC_URI[sha256sum] = "740eee3327acfb462b8460519a219e30dc0a870326e88e2ddc4fe2c8de20b1c9"
 

--- a/recipes-browser/wpebackend-fdo/wpebackend-fdo_1.8.0.bb
+++ b/recipes-browser/wpebackend-fdo/wpebackend-fdo_1.8.0.bb
@@ -1,5 +1,6 @@
 require wpebackend-fdo.inc
-require conf/include/devupstream.inc
+
+inherit cmake
 
 SRC_URI = "https://wpewebkit.org/releases/${BPN}-${PV}.tar.xz"
 SRC_URI[sha256sum] = "9652a99c75fe1c6eab0585b6395f4e104b2427e4d1f42969f1f77df29920d253"
@@ -8,6 +9,3 @@ SRC_URI[sha256sum] = "9652a99c75fe1c6eab0585b6395f4e104b2427e4d1f42969f1f77df299
 # TODO: Promote it to the wpebackend-fdo.inc once wpebackend-fdo=1.6.1 is
 # removed from this repo.
 DEPENDS = "glib-2.0 libxkbcommon wayland libepoxy libwpe"
-
-SRC_URI_class-devupstream = "git://github.com/Igalia/WPEBackend-fdo.git;protocol=https;branch=master"
-SRCREV_class-devupstream = "6796611f4a0c5b11ebc58466d73880ef2781e4ef"

--- a/recipes-browser/wpebackend-fdo/wpebackend-fdo_devupstream.bb
+++ b/recipes-browser/wpebackend-fdo/wpebackend-fdo_devupstream.bb
@@ -1,0 +1,16 @@
+require wpebackend-fdo.inc
+require conf/include/devupstream.inc
+
+# wpebackend-fdo uses meson since (not branched yet)
+#   https://github.com/Igalia/WPEBackend-fdo/commit/9c13d73bcc3726e2290c182d76d67b384f4c1318
+inherit meson
+
+DEFAULT_PREFERENCE = "-1"
+
+# These dependencies are needed since wpebackend-fdo>=1.8.X
+# TODO: Promote it to the wpebackend-fdo.inc once wpebackend-fdo=1.6.1 is
+# removed from this repo.
+DEPENDS = "glib-2.0 libxkbcommon wayland libepoxy libwpe"
+
+SRC_URI = "git://github.com/Igalia/WPEBackend-fdo.git;protocol=https;branch=master"
+SRCREV = "6796611f4a0c5b11ebc58466d73880ef2781e4ef"


### PR DESCRIPTION
We can not use SRCREV to discern for what version is being processed in the bitbake execution to chose what class inherit. For example:
    
      inherit ${@bb.utils.contains("SRCREV", 'INVALID', 'cmake', 'meson', d)}
    
That line is not valid because d.getVar(d, "SRCREV") is evaluated always to INVALID in this stage.
    
This patch moves the class-devupstream customizations to a new recipe (wpebackend-fdo_devupstream.bb). In addition, the 'inherit' statement is explicitly declared in each recipe.
    
This fix the regression introduced in 2665a3d557b3c12b891898eb412545ee63aff273 building the bleeding-edge version.
    
Unreviewed patch.
    
Signed-off-by: Pablo Saavedra <psaavedra@igalia.com>
