### PR TITLE
Create close_stale_issues_and_pr.yml

### DIFF
--- a/.github/workflows/close_stale_issues_and_pr.yml
+++ b/.github/workflows/close_stale_issues_and_pr.yml
@@ -12,8 +12,8 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           stale-issue-message: 'This issue is stale because it has been open 365 days with no activity. Remove stale label or comment or this will be closed in 7 days.'
           stale-pr-message: 'This PR is stale because it has been open 365 days with no activity.'
-          close-issue-message: 'This issue was closed because it has been stalled for 7 days with no activity.'
-          close-pr-message: 'This PR was closed because it has been stalled for 7 days with no activity.'
+          close-issue-message: 'This issue was closed because it has been stale for 7 days with no activity.'
+          close-pr-message: 'This PR was closed because it has been stale for 7 days with no activity.'
           stale-issue-label: 'no-issue-activity'
           stale-pr-label: 'no-pr-activity'
           exempt-issue-labels: 'awaiting-approval,work-in-progress'

--- a/.github/workflows/close_stale_issues_and_pr.yml
+++ b/.github/workflows/close_stale_issues_and_pr.yml
@@ -1,0 +1,25 @@
+name: 'Close stale issues and PR'
+on:
+  schedule:
+    - cron: '30 3 * * *'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          stale-issue-message: 'This issue is stale because it has been open 365 days with no activity. Remove stale label or comment or this will be closed in 7 days.'
+          stale-pr-message: 'This PR is stale because it has been open 365 days with no activity.'
+          close-issue-message: 'This issue was closed because it has been stalled for 7 days with no activity.'
+          close-pr-message: 'This PR was closed because it has been stalled for 7 days with no activity.'
+          stale-issue-label: 'no-issue-activity'
+          stale-pr-label: 'no-pr-activity'
+          exempt-issue-labels: 'awaiting-approval,work-in-progress'
+          exempt-pr-labels: 'awaiting-approval,work-in-progress'
+          only-labels: 'awaiting-feedback,awaiting-answers'
+          days-before-issue-stale: 365
+          days-before-pr-stale: 365
+          days-before-issue-close: 7
+          days-before-pr-close: -1


### PR DESCRIPTION
Setup a Github Action to set as _stale_ the Issues and PR with no activity since 365. After +7 days without activity, a _stale_ issue is closed.

Documentation: https://github.com/marketplace/actions/close-stale-issues