### PR TITLE
Fix several warnings in the webkitgtk_2.30.X in gatesgarth #211

### DIFF
--- a/recipes-browser/webkitgtk/webkitgtk_2.30.5.bb
+++ b/recipes-browser/webkitgtk/webkitgtk_2.30.5.bb
@@ -30,7 +30,7 @@ inherit cmake lib_package pkgconfig perlnative python3native
 #   Temporarily support the old class name with a warning about future deprecation.
 inherit ${@bb.utils.contains_any("LAYERSERIES_CORENAMES", 'zeus warrior', 'distro_features_check', 'features_check', d)}
 
-S = "${WORKDIR}/webkitgtk-${PV}/"
+S = "${WORKDIR}/webkitgtk-${PV}"
 
 # To build with embedded gl support -> Enable *both* "opengl" and "gles2" option
 # To build with desktop  gl support -> Enable "opengl", but disable "gles2" option

--- a/recipes-browser/webkitgtk/webkitgtk_2.30.5.bb
+++ b/recipes-browser/webkitgtk/webkitgtk_2.30.5.bb
@@ -25,11 +25,6 @@ RRECOMMENDS_${PN}-bin = "adwaita-icon-theme librsvg-gtk"
 
 inherit cmake lib_package pkgconfig perlnative python3native
 
-# distro_features_check is going to be removed after dunfell
-# ref: https://git.yoctoproject.org/cgit/cgit.cgi/poky/commit/meta/classes/features_check.bbclass?h=master-next&id=9702544b3e75d761d86cae7e8b36f3f2625b68ce
-#   Temporarily support the old class name with a warning about future deprecation.
-inherit ${@bb.utils.contains_any("LAYERSERIES_CORENAMES", 'zeus warrior', 'distro_features_check', 'features_check', d)}
-
 S = "${WORKDIR}/webkitgtk-${PV}"
 
 # To build with embedded gl support -> Enable *both* "opengl" and "gles2" option


### PR DESCRIPTION

Fixes:

* webkitgtk: Remove unused features_check
* webkitgtk: Fix recipe webkitgtk sets S variable with trailing slash

Related to https://github.com/Igalia/meta-webkit/issues/211