### PR TITLE
cog: Allow dbus owner user configuration

### DIFF
--- a/recipes-browser/cog/cog.inc
+++ b/recipes-browser/cog/cog.inc
@@ -40,10 +40,14 @@ FILES_SOLIBSDEV = "${libdir}/libcogcore*.so"
 FILES_${PN} += "${libdir}/libcogplatform*.so"
 INSANE_SKIP_${PN} = "dev-so"
 
+# Local user name starting cog with DBus system session enabled. This should be
+# set only if the dbus PACKAGECONFIG is enabled.
+COG_DBUS_OWN_USER ?= ""
+
 # Use WebKitGTK+ instead of WPEWebKit
 PACKAGECONFIG[webkitgtk] = "-DCOG_USE_WEBKITGTK=ON,-DCOG_USE_WEBKITGTK=OFF"
 # Expose remote control interface on system bus.
-PACKAGECONFIG[dbus] = "-DCOG_DBUS_SYSTEM_BUS=ON,-DCOG_DBUS_SYSTEM_BUS=OFF"
+PACKAGECONFIG[dbus] = "-DCOG_DBUS_SYSTEM_BUS=ON -DCOG_DBUS_OWN_USER=${COG_DBUS_OWN_USER},-DCOG_DBUS_SYSTEM_BUS=OFF"
 # Use wpebackend-fdo.
 PACKAGECONFIG[fdo] = "-DCOG_PLATFORM_FDO=ON,-DCOG_PLATFORM_FDO=OFF,wpebackend-fdo"
 PACKAGECONFIG[drm] = "-DCOG_PLATFORM_DRM=ON,-DCOG_PLATFORM_DRM=OFF,wpebackend-fdo libdrm virtual/libgbm libinput"


### PR DESCRIPTION
This is specially useful when the recipe is configured to enable system dbus
session support.