### PR TITLE
wpewebkit: apply upstream r274943 patch for the 2.30 and 2.32 releases

### DIFF
--- a/recipes-browser/wpewebkit/wpewebkit/274943-GStreamer-Use-imxvideoconvert_g2d-element-inside-the.patch
+++ b/recipes-browser/wpewebkit/wpewebkit/274943-GStreamer-Use-imxvideoconvert_g2d-element-inside-the.patch
@@ -1,0 +1,73 @@
+From 1b7c27370a261cb0a37b2674dfeaf41c2c0231f0 Mon Sep 17 00:00:00 2001
+From: "commit-queue@webkit.org"
+ <commit-queue@webkit.org@268f45cc-cd09-0410-ab3c-d52691b4dbfc>
+Date: Wed, 24 Mar 2021 16:59:39 +0000
+Subject: [PATCH xserver] [GStreamer] Use imxvideoconvert_g2d element inside
+ the sink when available https://bugs.webkit.org/show_bug.cgi?id=223693
+
+Patch by Zan Dobersek <zdobersek@igalia.com> on 2021-03-24
+Reviewed by Philippe Normand.
+
+On some iMX platforms we require the use of imxvideoconvert_g2d element
+in order to properly convert the visual buffers before they can be
+rendered through our pipeline. We expect to require this buffer if it's
+present in the GStreamer plugin registry on the system.
+
+We search for this element and, if found, add it to the sink and
+position it at the beginning, before the glupload element.
+
+Based on an approach outlined by Gabriel Valcazar.
+
+* platform/graphics/gstreamer/GLVideoSinkGStreamer.cpp:
+(webKitGLVideoSinkConstructed):
+
+git-svn-id: http://svn.webkit.org/repository/webkit/trunk@274943 268f45cc-cd09-0410-ab3c-d52691b4dbfc
+---
+ Source/WebCore/ChangeLog                      | 20 ++++++++++++++++++
+ .../gstreamer/GLVideoSinkGStreamer.cpp        | 21 ++++++++++++++++++-
+ 2 files changed, 40 insertions(+), 1 deletion(-)
+
+diff --git a/Source/WebCore/platform/graphics/gstreamer/GLVideoSinkGStreamer.cpp b/Source/WebCore/platform/graphics/gstreamer/GLVideoSinkGStreamer.cpp
+index 4b08901f372f..12c639ba8e17 100644
+--- a/Source/WebCore/platform/graphics/gstreamer/GLVideoSinkGStreamer.cpp
++++ b/Source/WebCore/platform/graphics/gstreamer/GLVideoSinkGStreamer.cpp
+@@ -68,6 +68,17 @@ static void webKitGLVideoSinkConstructed(GObject* object)
+     ASSERT(sink->priv->appSink);
+     g_object_set(sink->priv->appSink.get(), "enable-last-sample", FALSE, "emit-signals", TRUE, "max-buffers", 1, nullptr);
+ 
++    auto* imxVideoConvertG2D =
++        []() -> GstElement*
++        {
++            auto elementFactor = adoptGRef(gst_element_factory_find("imxvideoconvert_g2d"));
++            if (elementFactor)
++                return gst_element_factory_create(elementFactor.get(), nullptr);
++            return nullptr;
++        }();
++    if (imxVideoConvertG2D)
++        gst_bin_add(GST_BIN_CAST(sink), imxVideoConvertG2D);
++
+     GstElement* upload = gst_element_factory_make("glupload", nullptr);
+     GstElement* colorconvert = gst_element_factory_make("glcolorconvert", nullptr);
+     ASSERT(upload);
+@@ -96,9 +107,17 @@ static void webKitGLVideoSinkConstructed(GObject* object)
+     gst_caps_set_features(caps.get(), 0, gst_caps_features_new(GST_CAPS_FEATURE_MEMORY_GL_MEMORY, nullptr));
+     g_object_set(sink->priv->appSink.get(), "caps", caps.get(), nullptr);
+ 
++    if (imxVideoConvertG2D)
++        gst_element_link(imxVideoConvertG2D, upload);
+     gst_element_link_many(upload, colorconvert, sink->priv->appSink.get(), nullptr);
+ 
+-    GRefPtr<GstPad> pad = adoptGRef(gst_element_get_static_pad(upload, "sink"));
++    GstElement* sinkElement =
++        [&] {
++            if (imxVideoConvertG2D)
++                return imxVideoConvertG2D;
++            return upload;
++        }();
++    GRefPtr<GstPad> pad = adoptGRef(gst_element_get_static_pad(sinkElement, "sink"));
+     gst_element_add_pad(GST_ELEMENT_CAST(sink), gst_ghost_pad_new("sink", pad.get()));
+ }
+ 
+-- 
+2.30.2
+

--- a/recipes-browser/wpewebkit/wpewebkit_2.30.6.bb
+++ b/recipes-browser/wpewebkit/wpewebkit_2.30.6.bb
@@ -5,6 +5,7 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 SRC_URI = "\
     https://wpewebkit.org/releases/${BPN}-${PV}.tar.xz \
     file://216455_builds_with_ENABLE_SERVICE_WORKER_OFF.patch \
+    file://274943-GStreamer-Use-imxvideoconvert_g2d-element-inside-the.patch \
 "
 
 SRC_URI[sha256sum] = "893a3098226f116bbb38a665a3053c7d30e3c5dca786b954f9aa38f8c8581468"

--- a/recipes-browser/wpewebkit/wpewebkit_2.31.91.bb
+++ b/recipes-browser/wpewebkit/wpewebkit_2.31.91.bb
@@ -5,6 +5,7 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 SRC_URI = "\
     https://wpewebkit.org/releases/${BPN}-${PV}.tar.xz \
     file://0001-EME-Fix-KeySystem-permission-handling.patch \
+    file://274943-GStreamer-Use-imxvideoconvert_g2d-element-inside-the.patch \
 "
 
 SRC_URI[sha256sum] = "e5bea1323ad810533bcb7ec7918b4bc2d342b0ea2a2fa61a3063cdd019bcd3f0"


### PR DESCRIPTION
Provide and apply the upstream r274943 patch on top of the currently-used
2.30 and 2.32 releases.

This patch adjusts the GStreamer sink creation by including the
imxvideoconvert_g2d element at the beginning of the sink if it's found to be
present on the system. This converter element is needed on some iMX platforms
(generally the ones it's provided on) to perform additional conversion passes
to make the visual output presentable in our pipeline.

It's not a given that the patch will be merged into the 2.30 stable series,
hence it's being added here. It will be included in the next unstable release
so it should be removable whenever the 2.32 version is updated.