### PR TITLE
wpebackend-fdo: adjust the source directory for the devupstream version.

### DIFF
--- a/recipes-browser/wpebackend-fdo/wpebackend-fdo_devupstream.bb
+++ b/recipes-browser/wpebackend-fdo/wpebackend-fdo_devupstream.bb
@@ -14,3 +14,4 @@ DEPENDS = "glib-2.0 libxkbcommon wayland libepoxy libwpe"
 
 SRC_URI = "git://github.com/Igalia/WPEBackend-fdo.git;protocol=https;branch=master"
 SRCREV = "6796611f4a0c5b11ebc58466d73880ef2781e4ef"
+S = "${WORKDIR}/git"


### PR DESCRIPTION
It's a git checkout, so the source directory has to be adjusted accordingly. Otherwise, an error pops up during the license validation since the COPYING file isn't found.