### PR TITLE
browserperfrunner,core-image-wpe-crosscompilation: Drop older than du…

### DIFF
--- a/recipes-benchmark/browserperfrunner/browserperfrunner_git.bb
+++ b/recipes-benchmark/browserperfrunner/browserperfrunner_git.bb
@@ -22,15 +22,11 @@ RDEPENDS_${PN} = " curl make patch perl procps psmisc python python-misc \
 # This recipe still requires python2.
 # So on Yocto dunfell and later its needed to use meta-python2
 # Port to python3 tracked at https://github.com/Igalia/browserperfrunner/issues/3
-inherit ${@bb.utils.contains_any("LAYERSERIES_CORENAMES", "warrior thud sumo", \
-        "python-dir", \
-        bb.utils.contains("BBFILE_COLLECTIONS", "meta-python2", "python-dir", "", d), \
-        d)}
+inherit ${@bb.utils.contains("BBFILE_COLLECTIONS", "meta-python2", "python-dir", "", d)}
 
 python() {
-    if d.getVar('LAYERSERIES_CORENAMES') not in ["warrior", "thud", "sumo"]:
-        if "meta-python2" not in d.getVar("BBFILE_COLLECTIONS").split():
-            raise bb.parse.SkipRecipe("Requires meta-python2 to be present.")
+    if "meta-python2" not in d.getVar("BBFILE_COLLECTIONS").split():
+        raise bb.parse.SkipRecipe("Requires meta-python2 to be present.")
 }
 
 do_install() {

--- a/recipes-browser/images/core-image-wpe-crosscompilation.bb
+++ b/recipes-browser/images/core-image-wpe-crosscompilation.bb
@@ -5,12 +5,7 @@ SUMMARY = "WPE cross-compilation image with wpebackend-fdo. \
 
 LICENSE = "BSD"
 
-inherit core-image
-
-# distro_features_check is going to be removed after dunfell
-# ref: https://git.yoctoproject.org/cgit/cgit.cgi/poky/commit/meta/classes/features_check.bbclass?h=master-next&id=9702544b3e75d761d86cae7e8b36f3f2625b68ce
-#   Temporarily support the old class name with a warning about future deprecation.
-inherit ${@bb.utils.contains_any("LAYERSERIES_CORENAMES", 'warrior', 'distro_features_check', 'features_check', d)}
+inherit core-image features_check
 
 REQUIRED_DISTRO_FEATURES = "wayland"
 


### PR DESCRIPTION
…nfell layer support

dunfell is oldest release supported on main branch, therefore drop the
unneeded complexity to check for older layers

Signed-off-by: Khem Raj <raj.khem@gmail.com>