### PR TITLE
qt-wpe-simple-browser: fix runtime and build dependencies

### DIFF
--- a/dynamic-layers/qt5-layer/recipes-qt/qt-wpe-simple-browser/qt-wpe-simple-browser_0.1.bb
+++ b/dynamic-layers/qt5-layer/recipes-qt/qt-wpe-simple-browser/qt-wpe-simple-browser_0.1.bb
@@ -2,8 +2,8 @@ SUMMARY = "Qt5 WPE simple browser application"
 LICENSE = "LGPL-2.1+"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/LGPL-2.1-or-later;md5=2a4f4fd2128ea2f65047ee63fbca9f68"
 
-DEPENDS += "qtbase qtdeclarative qtquickcontrols2 wpewebkit"
-RDEPENDS_${PN} += " wpewebkit-qtwpe-qml-plugin"
+DEPENDS = "qtbase qtdeclarative"
+RDEPENDS_${PN} = "wpewebkit wpewebkit-qtwpe-qml-plugin"
 
 SRC_URI = "file://CMakeLists.txt \
            file://main.cpp \


### PR DESCRIPTION
This PR cleanup the deps so all Yocto mechanisms are working correctly.