### PR TITLE
webkitgtk: Fix reproducibility

### DIFF
--- a/recipes-browser/webkitgtk/webkitgtk/0001-MiniBrowser-Fix-reproduciblity.patch
+++ b/recipes-browser/webkitgtk/webkitgtk/0001-MiniBrowser-Fix-reproduciblity.patch
@@ -1,0 +1,31 @@
+From dcf9ae0dc0b4510eddbeeea09e11edfb123f95af Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Sun, 2 May 2021 13:10:49 -0700
+Subject: [PATCH] MiniBrowser: Fix reproduciblity
+
+Do not emit references to source dir in generated sourcecode
+
+Upstream-Status: Submitted [https://bugs.webkit.org/show_bug.cgi?id=225283]
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ Tools/MiniBrowser/gtk/CMakeLists.txt | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/Tools/MiniBrowser/gtk/CMakeLists.txt b/Tools/MiniBrowser/gtk/CMakeLists.txt
+index 93b62521..482d3b00 100644
+--- a/Tools/MiniBrowser/gtk/CMakeLists.txt
++++ b/Tools/MiniBrowser/gtk/CMakeLists.txt
+@@ -51,8 +51,8 @@ add_custom_command(
+     OUTPUT ${MiniBrowser_DERIVED_SOURCES_DIR}/BrowserMarshal.c
+            ${MiniBrowser_DERIVED_SOURCES_DIR}/BrowserMarshal.h
+     MAIN_DEPENDENCY ${MiniBrowser_DIR}/browser-marshal.list
+-    COMMAND glib-genmarshal --prefix=browser_marshal ${MiniBrowser_DIR}/browser-marshal.list --body > ${MiniBrowser_DERIVED_SOURCES_DIR}/BrowserMarshal.c
+-    COMMAND glib-genmarshal --prefix=browser_marshal ${MiniBrowser_DIR}/browser-marshal.list --header > ${MiniBrowser_DERIVED_SOURCES_DIR}/BrowserMarshal.h
++    COMMAND glib-genmarshal --prefix=browser_marshal ${MiniBrowser_DIR}/browser-marshal.list --body --skip-source > ${MiniBrowser_DERIVED_SOURCES_DIR}/BrowserMarshal.c
++    COMMAND glib-genmarshal --prefix=browser_marshal ${MiniBrowser_DIR}/browser-marshal.list --header --skip-source > ${MiniBrowser_DERIVED_SOURCES_DIR}/BrowserMarshal.h
+     VERBATIM)
+ 
+ if (USE_GTK4)
+-- 
+2.31.1
+

--- a/recipes-browser/webkitgtk/webkitgtk_2.32.0.bb
+++ b/recipes-browser/webkitgtk/webkitgtk_2.32.0.bb
@@ -16,6 +16,7 @@ SRC_URI = "https://www.webkitgtk.org/releases/webkitgtk-${PV}.tar.xz \
            file://musl.patch \
            file://0001-ICU-69-deprecates-ubrk_safeClone-in-favor-of-ubrk_cl.patch \
            file://0001-Move-cloneUBreakIterator-declaration-to-IntlWorkarou.patch \
+           file://0001-MiniBrowser-Fix-reproduciblity.patch \
            "
 SRC_URI[sha256sum] = "9d7df4dae9ada2394257565acc2a68ace9308c4c61c3fcc00111dc1f11076bf0"
 


### PR DESCRIPTION
Pass --skip-source to glib-genmarshal to stop emitting full src path
into generated sources

Signed-off-by: Khem Raj <raj.khem@gmail.com>