### PR TITLE
cog: Fix SRC_URI

### DIFF
--- a/recipes-browser/cog/cog_0.8.1.bb
+++ b/recipes-browser/cog/cog_0.8.1.bb
@@ -1,7 +1,7 @@
 require cog.inc
 require conf/include/devupstream.inc
 
-SRC_URI = "https://github.com/Igalia/cog/releases/download/v${PV}/cog-${PV}.tar.xz"
+SRC_URI = "https://github.com/Igalia/cog/releases/download/${PV}/${BP}.tar.xz"
 
 SRC_URI[sha256sum] = "b82e917eb764943b9859c631974f8f0e748b79ae87bb7a944f46c818740e0208"
 


### PR DESCRIPTION
It does not use v${PV} anymore and use BP instead of cog-${PV} while
here

Signed-off-by: Khem Raj <raj.khem@gmail.com>