### PR TITLE
cog: add D-Bus policy configuration to FILES_${PN} to fix QA issue

### DIFF
--- a/recipes-browser/cog/cog.inc
+++ b/recipes-browser/cog/cog.inc
@@ -39,7 +39,14 @@ PACKAGECONFIG ?= " ${@bb.utils.contains('PREFERRED_PROVIDER_virtual/wpebackend',
 # https://github.com/Igalia/cog/commit/758ed08555e8152a2becd2178d1f3a4ce6e67af9
 # Also libWPEBackend-default.so should go into the main package.
 FILES_SOLIBSDEV = "${libdir}/libcogcore*.so"
-FILES_${PN} += "${libdir}/libcogplatform*.so"
+
+# cog < 0.10.0 installed D-Bus policy configuration into sysconfdir
+# cog >= 0.10.0 installs it into datadir, see https://github.com/Igalia/cog/pull/296
+FILES_${PN} += " \
+    ${libdir}/libcogplatform*.so \
+    ${sysconfdir}/dbus-1/system.d/com.igalia.Cog.conf \
+    ${datadir}/dbus-1/system.d/com.igalia.Cog.conf \
+"
 INSANE_SKIP_${PN} = "dev-so"
 
 # Local user name starting cog with DBus system session enabled. This should be


### PR DESCRIPTION
Add the D-Bus policy configuration file into the list of files that should be included in the resulting cog package.

Fixes this QA issue with dbus packageconfig:

```
ERROR: cog-0.10.0-r0 do_package: QA Issue: cog: Files/directories were installed but not shipped in any package:
  /usr/share/dbus-1
  /usr/share/dbus-1/system.d
  /usr/share/dbus-1/system.d/com.igalia.Cog.conf
Please set FILES such that these items are packaged. Alternatively if they are unneeded, avoid installing them or delete them within do_install.
cog: 3 installed and not shipped files. [installed-vs-shipped]
ERROR: cog-0.10.0-r0 do_package: Fatal QA errors found, failing task.
```