### PR TITLE
wpewebkit: Add libgles2 to runtime dependencies

### DIFF
--- a/recipes-browser/wpewebkit/wpewebkit.inc
+++ b/recipes-browser/wpewebkit/wpewebkit.inc
@@ -83,6 +83,7 @@ ARM_INSTRUCTION_SET_armv7ve = "thumb"
 
 # Extra runtime depends
 RDEPENDS_${PN} += " \
+    libgles2 \
     virtual/wpebackend \
     ${@bb.utils.contains('PACKAGECONFIG', 'mediasource', 'gstreamer1.0-plugins-good-isomp4', '', d)} \
     ${@bb.utils.contains('PACKAGECONFIG', 'webaudio', 'gstreamer1.0-plugins-good-wavparse', '', d)} \


### PR DESCRIPTION
libgles2 is a runtime dependency of wpewebkit.  Currently libgles2 is
specified as a dependency, but the library isn't directly linked against
by wpewebkit.  This is because wpewebkit uses libepoxy, which loads
libgles2 via dlopen.

Since libgles2 is a runtime dependency of wpewebkit, even though it is
not directly linked against, it is now listed in RDEPENDS.

Signed-off-by: Colin McAllister <colin.mcallister@garmin.com>