### PR TITLE
cog: Bump up version to 0.10.0

### DIFF
--- a/recipes-browser/cog/cog.inc
+++ b/recipes-browser/cog/cog.inc
@@ -9,6 +9,8 @@ BUGTRACKER = "https://github.com/Igalia/cog/issues"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://COPYING;md5=bf1229cd7425b302d60cdb641b0ce5fb"
 
+SRC_URI = "https://wpewebkit.org/releases/${P}.tar.xz"
+
 # Depend on wpewebkit unless the webkitgtk packageconfig option is selected.
 DEPENDS = " \
             ${@bb.utils.contains('PACKAGECONFIG', 'webkitgtk', 'webkitgtk', 'wpewebkit', d)} \
@@ -47,3 +49,4 @@ PACKAGECONFIG[dbus] = "-DCOG_DBUS_SYSTEM_BUS=ON,-DCOG_DBUS_SYSTEM_BUS=OFF"
 # Use wpebackend-fdo.
 PACKAGECONFIG[fdo] = "-DCOG_PLATFORM_FDO=ON,-DCOG_PLATFORM_FDO=OFF,wpebackend-fdo"
 PACKAGECONFIG[drm] = "-DCOG_PLATFORM_DRM=ON,-DCOG_PLATFORM_DRM=OFF,wpebackend-fdo libdrm virtual/libgbm libinput"
+PACKAGECONFIG[weston-direct-display] = "-DCOG_WESTON_DIRECT_DISPLAY=ON,-DCOG_WESTON_DIRECT_DISPLAY=OFF,weston"

--- a/recipes-browser/cog/cog_0.10.0.bb
+++ b/recipes-browser/cog/cog_0.10.0.bb
@@ -1,0 +1,9 @@
+require cog.inc
+require conf/include/devupstream.inc
+
+SRC_URI[sha256sum] = "2c72369c636ca4684370adad1344071b23c9ee2c851eb7d738fa2e1d7092031f"
+
+SRC_URI_class-devupstream = "git://github.com/Igalia/cog.git;protocol=https;branch=master"
+SRCREV_class-devupstream = "10f0360cd1ef9f8258d7d4a06d4ab113f5635995"
+
+RDEPENDS_${PN} += "wpewebkit (>= 2.28)"

--- a/recipes-browser/cog/cog_0.8.1.bb
+++ b/recipes-browser/cog/cog_0.8.1.bb
@@ -1,11 +1,6 @@
 require cog.inc
 require conf/include/devupstream.inc
 
-SRC_URI = "https://github.com/Igalia/cog/releases/download/${PV}/cog-${PV}.tar.xz"
-
 SRC_URI[sha256sum] = "b82e917eb764943b9859c631974f8f0e748b79ae87bb7a944f46c818740e0208"
-
-SRC_URI_class-devupstream = "git://github.com/Igalia/cog.git;protocol=https;branch=master"
-SRCREV_class-devupstream = "fcffa7a82b960dd514a2fee5edcce660acce73e7"
 
 RDEPENDS_${PN} += "wpewebkit (>= 2.28)"


### PR DESCRIPTION
Addresses issues #284 and #290 

Release notes: https://wpewebkit.org/release/cog-0.10.0.html

Change-Id: Ie32953319384d0dba5a3094ccf9e2f56a23cc5bb
Signed-off-by: Pablo Saavedra <psaavedra@igalia.com>