### PR TITLE
cog: Fix SRC_URI for cog 0.8.1

### DIFF
--- a/recipes-browser/cog/cog.inc
+++ b/recipes-browser/cog/cog.inc
@@ -9,6 +9,8 @@ BUGTRACKER = "https://github.com/Igalia/cog/issues"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://COPYING;md5=bf1229cd7425b302d60cdb641b0ce5fb"
 
+SRC_URI = "https://wpewebkit.org/releases/${P}.tar.xz"
+
 # Depend on wpewebkit unless the webkitgtk packageconfig option is selected.
 DEPENDS = " \
             ${@bb.utils.contains('PACKAGECONFIG', 'webkitgtk', 'webkitgtk', 'wpewebkit', d)} \
@@ -47,3 +49,4 @@ PACKAGECONFIG[dbus] = "-DCOG_DBUS_SYSTEM_BUS=ON,-DCOG_DBUS_SYSTEM_BUS=OFF"
 # Use wpebackend-fdo.
 PACKAGECONFIG[fdo] = "-DCOG_PLATFORM_FDO=ON,-DCOG_PLATFORM_FDO=OFF,wpebackend-fdo"
 PACKAGECONFIG[drm] = "-DCOG_PLATFORM_DRM=ON,-DCOG_PLATFORM_DRM=OFF,wpebackend-fdo libdrm virtual/libgbm libinput"
+PACKAGECONFIG[weston-direct-display] = "-DCOG_WESTON_DIRECT_DISPLAY=ON,-DCOG_WESTON_DIRECT_DISPLAY=OFF,weston"

--- a/recipes-browser/cog/cog_0.8.1.bb
+++ b/recipes-browser/cog/cog_0.8.1.bb
@@ -1,11 +1,6 @@
 require cog.inc
 require conf/include/devupstream.inc
 
-SRC_URI = "https://github.com/Igalia/cog/releases/download/${PV}/cog-${PV}.tar.xz"
-
 SRC_URI[sha256sum] = "b82e917eb764943b9859c631974f8f0e748b79ae87bb7a944f46c818740e0208"
-
-SRC_URI_class-devupstream = "git://github.com/Igalia/cog.git;protocol=https;branch=master"
-SRCREV_class-devupstream = "fcffa7a82b960dd514a2fee5edcce660acce73e7"
 
 RDEPENDS_${PN} += "wpewebkit (>= 2.28)"


### PR DESCRIPTION
Pulled in chagnes to cog 0.8.1 recipe in main to fix SRC_URI for cog 0.8.1.

Signed-off-by: Colin McAllister <colin.mcallister@garmin.com>