### PR TITLE
Create manual-check-external-pr.yml

### DIFF
--- a/.github/workflows/manual-check-external-pr.yml
+++ b/.github/workflows/manual-check-external-pr.yml
@@ -1,0 +1,47 @@
+name: 'Manual check for external Pull Requests'
+on:
+  workflow_dispatch:
+    inputs:
+      pr-id:
+        description: 'Pull Request Id'
+        required: true
+        default: '0'
+
+jobs:
+  check-external-pr:
+    runs-on: ubuntu-latest
+    name: Create an internal branch for check the MR into the CI
+    env:
+      BOT_USER: "meta-webkit bot"
+      BOT_EMAIL: "meta-webkit@igalia.com"
+      REPO: git@github.com:Igalia/meta-webkit.git
+      MIRROR: git@gitlab.com:browsers/meta-webkit.git
+    steps:
+    - run: |
+       # Set the $SSH_PRIVATE_KEY environment variable in the CI to the base64
+       # encoded private key generated like this:
+       #   ssh-keygen  -t ecdsa -f runner_ecdsa
+       #   cat runner_ecdsa | base64 -w0
+       echo "Creating branch for Pull request \#${{ github.event.inputs.pr-id }}"
+       eval $(ssh-agent -s)
+       (echo "${{ secrets.SSH_PRIVATE_KEY }}" | base64 --decode | ssh-add -) || true
+       mkdir -p ~/.ssh
+       chmod 700 ~/.ssh
+       ssh-keyscan -t rsa gitlab.com github.com >>~/.ssh/known_hosts
+       git config --global user.name "${{ env.BOT_USER }}"
+       git config --global user.email "${{ env.BOT_EMAIL }}"
+       git config --global pull.rebase "preserve"
+       git clone ${{ env.REPO }} repo
+       cd repo
+       git remote add gitlab ${{ env.MIRROR }}
+       git fetch ${{ env.REPO }} pull/${{ github.event.inputs.pr-id }}/head:pull/${{ github.event.inputs.pr-id }}
+       git checkout pull/${{ github.event.inputs.pr-id }}
+       git push --force gitlab pull/${{ github.event.inputs.pr-id }}
+       curl -X POST \
+         -H "PRIVATE-TOKEN: ${{ secrets.GITLAB_TOKEN }}" \
+         "https://gitlab.com/api/v4/projects/browsers%2Fmeta-webkit/mirror/pull"
+       curl -X POST \
+         -H "Accept: application/vnd.github.v3+json" \
+         -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+         "https://api.github.com/repos/Igalia/meta-webkit/issues/${{ github.event.inputs.pr-id }}/comments" \
+         -d '{"body":"Pull Request is being checked for https://github.com/Igalia/meta-webkit/pull/${{ github.event.inputs.pr-id }}/commits"}'

--- a/.github/workflows/manual-cleanup-mirrored-external-pr.yml
+++ b/.github/workflows/manual-cleanup-mirrored-external-pr.yml
@@ -1,0 +1,33 @@
+name: 'Manual clean-up of the mirrored external Pull Requests'
+on:
+  workflow_dispatch:
+
+jobs:
+  check-external-pr:
+    runs-on: ubuntu-latest
+    name: Create an internal branch for check the MR into the CI
+    env:
+      BOT_USER: "meta-webkit bot"
+      BOT_EMAIL: "meta-webkit@igalia.com"
+      MIRROR: git@gitlab.com:browsers/meta-webkit.git
+    steps:
+    - run: |
+       # Set the $SSH_PRIVATE_KEY environment variable in the CI to the base64
+       # encoded private key generated like this:
+       #   ssh-keygen  -t ecdsa -f runner_ecdsa
+       #   cat runner_ecdsa | base64 -w0
+       echo "Creating branch for Pull request \#${{ github.event.inputs.pr-id }}"
+       eval $(ssh-agent -s)
+       (echo "${{ secrets.SSH_PRIVATE_KEY }}" | base64 --decode | ssh-add -) || true
+       mkdir -p ~/.ssh
+       chmod 700 ~/.ssh
+       ssh-keyscan -t rsa gitlab.com >> ~/.ssh/known_hosts
+       git config --global user.name "${{ env.BOT_USER }}"
+       git config --global user.email "${{ env.BOT_EMAIL }}"
+       git config --global pull.rebase "preserve"
+       git clone ${{ env.MIRROR }} repo
+       cd repo
+       for b in $(git branch --remote --list origin/pull*)
+         do
+           git push origin --delete "$(echo ${b} | cut -f 2- -d '/')"
+       done


### PR DESCRIPTION
This Github Action allows to manually create a new branch in the CI mirror repo the under the `pull/` path based on the changes suggested by an external Pull Request from an forked repository. This push triggers the CI jobs in the Gitlab CI.

This action **does**:

* force the push of the `pull/<id>/HEAD` branch in the mirror. It also notifies to the Gitlab CI for a immediate pull of the mirror (this last is not strictly necessary)
* Puts a comment into the Pull Request pointing to the created branch

This action has some **limitations**:

* ~~The results of the CI jobs are not linked to the original Pull Request. Instead of that that relies in a manual action by the reviewer who have to put a comment in the PR linking the results.~~. I've noticed that this works if the references (hash) for the HEAD commit what triggers the pipeline is the same that the `HEAD` in the `pull/<id>/HEAD` branch.
* This action has to be manually triggered by a reviewer. To run code from forked repos still implies several security concerns . See: https://gitlab.com/gitlab-org/gitlab/-/issues/5667#permissions-and-security 