### PR TITLE
wpewebkit: Bump up version to 2.32.3

### DIFF
--- a/recipes-browser/webkitgtk/webkitgtk_2.32.3.bb
+++ b/recipes-browser/webkitgtk/webkitgtk_2.32.3.bb
@@ -15,7 +15,7 @@ DEPENDS = "zlib libsoup-2.4 curl libxml2 cairo libxslt libidn \
 SRC_URI = "https://www.webkitgtk.org/releases/webkitgtk-${PV}.tar.xz;name=tarball \
            file://0001-MiniBrowser-Fix-reproduciblity.patch;name=minibrowser \
            "
-SRC_URI[tarball.sha256sum] = "136117317f70f66486f71b8edf5e46f8776403c5d8a296e914b11a36ef836917"
+SRC_URI[tarball.sha256sum] = "c1f496f5ac654efe4cef62fbd4f2fbeeef265a07c5e7419e5d2900bfeea52cbc"
 SRC_URI[minibrowser.sha256sum] = "5729da9f7379ddc4e669f4c80d60d38bef8e84f7e0146dc319a63061cee4ceeb"
 
 RRECOMMENDS_${PN} = "${PN}-bin \

--- a/recipes-browser/wpewebkit/wpewebkit_2.32.3.bb
+++ b/recipes-browser/wpewebkit/wpewebkit_2.32.3.bb
@@ -7,11 +7,12 @@ SRC_URI = "\
     https://wpewebkit.org/releases/${BPN}-${PV}.tar.xz;name=tarball \
 "
 
-SRC_URI[tarball.sha256sum] = "7b6b39a12ccf3f84da4cc6ac59e02fbe328f7476eaeb9c23de9b9288c2c2f39c"
+SRC_URI[tarball.sha256sum] = "859bd1bbe51026aecfb2b6f5c8c024d88fb69ac6fcdc74c788c9fbe9499d740d"
 
 DEPENDS += " libwpe"
 RCONFLICTS_${PN} = "libwpe (< 1.4) wpebackend-fdo (< 1.6)"
 
 SRC_URI_class-devupstream = "git://git.webkit.org/WebKit.git;branch=master"
-SRCREV_class-devupstream = "b410adfdbd2835d90a4bf86282ba742448848c94"
+# WPE 2.32.X branch is forked from the main branch in this commit
+SRCREV_class-devupstream = "ed89819cebb141376ca22988844765637425e095"
 


### PR DESCRIPTION
Release notes: https://wpewebkit.org/release/wpewebkit-2.32.3.html

* Properly set the cookies settings after a network process crash.
* Fix accessibility tree after a cross site navigation with PSON enabled.
* Ensure WebKitScriptWorld::window-object-cleared signal is always emitted.
* Fix several crashes and rendering issues.

Release notes: https://wpewebkit.org/release/wpewebkit-2.32.2.html

* Improve the touch gesture touch controller.
* Fix handling of wheel events for devices which produce axis events.
* Fix kinetic scrolling on touchpad with async scrolling off.
* Fix a crash on empty drag operation in X11.
* Handle null native surface for for surfaceless rendering.
* Fix JavaScriptCore crash on 32-bit big endian systems.
* Fix several crashes and rendering issues.