### PR TITLE
layer.conf: add honister and kirkstone to compatible release branches

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -29,44 +29,59 @@
   variables:
     # setup-environment targetname machine distro bblayers presets
     # SOURCE: raspberrypi3-mesa-wpe-2.32 raspberrypi3-mesa poky raspberrypi mesa-wpe-2.32
-    # MANIFEST: .gitlab-ci/manifest/manifest-hardknott.xml
+    # MANIFEST: .gitlab-ci/manifest/manifest-honister.xml
     BITBAKE_TARGET: wpewebkit
   script:
     - bitbake $BITBAKE_TARGET
     - rm -rf tmp
 
-hardknott-raspberrypi3-mesa-weston-wpe-musl:
+kirkstone-raspberrypi3-mesa-weston-wpe-2.32:
   extends:
     - .raspberrypi3-mesa-weston-wpe
   allow_failure: true
   variables:
-    MANIFEST: .gitlab-ci/manifest/manifest-hardknott.xml
+    MANIFEST: .gitlab-ci/manifest/manifest-kirkstone.xml
+    SOURCE: raspberrypi3-mesa-wpe-2.32 raspberrypi3-mesa poky raspberrypi mesa-wpe-2_32
+
+honister-raspberrypi3-mesa-weston-wpe-musl:
+  extends:
+    - .raspberrypi3-mesa-weston-wpe
+  allow_failure: true
+  variables:
+    MANIFEST: .gitlab-ci/manifest/manifest-honister.xml
     SOURCE: raspberrypi3-mesa-wpe-musl raspberrypi3-mesa poky raspberrypi mesa-wpe-2_32
   script:
     - TCLIBC=musl bitbake $BITBAKE_TARGET
     - rm -rf tmp
 
-hardknott-raspberrypi3-mesa-weston-wpe-qt:
+honister-raspberrypi3-mesa-weston-wpe-qt:
   extends:
     - .raspberrypi3-mesa-weston-wpe
   allow_failure: true
   variables:
-    MANIFEST: .gitlab-ci/manifest/manifest-hardknott.xml
+    MANIFEST: .gitlab-ci/manifest/manifest-honister.xml
     SOURCE: raspberrypi3-mesa-wpe-qt raspberrypi3-mesa poky qt5 mesa-wpe-qt
 
-hardknott-raspberrypi3-mesa-weston-wpe-2.30:
+honister-raspberrypi3-mesa-weston-wpe-2.30:
   extends:
     - .raspberrypi3-mesa-weston-wpe
   variables:
-    MANIFEST: .gitlab-ci/manifest/manifest-hardknott.xml
+    MANIFEST: .gitlab-ci/manifest/manifest-honister.xml
     SOURCE: raspberrypi3-mesa-wpe-2.30 raspberrypi3-mesa poky raspberrypi mesa-wpe-2_30
+
+honister-raspberrypi3-mesa-weston-wpe-2.32:
+  extends:
+    - .raspberrypi3-mesa-weston-wpe
+  variables:
+    MANIFEST: .gitlab-ci/manifest/manifest-honister.xml
+    SOURCE: raspberrypi3-mesa-wpe-2.32 raspberrypi3-mesa poky raspberrypi mesa-wpe-2_32
 
 hardknott-raspberrypi3-mesa-weston-wpe-2.32:
   extends:
     - .raspberrypi3-mesa-weston-wpe
   variables:
     MANIFEST: .gitlab-ci/manifest/manifest-hardknott.xml
-    SOURCE: raspberrypi3-mesa-wpe-2.32 raspberrypi3-mesa poky raspberrypi mesa-wpe-2_32
+    SOURCE: raspberrypi3-mesa-wpe-2.32 raspberrypi3-mesa poky raspberrypi mesa-wpe-2.32
 
 gatesgarth-raspberrypi3-mesa-weston-wpe-2.32:
   extends:

--- a/.gitlab-ci/manifest/manifest-honister.xml
+++ b/.gitlab-ci/manifest/manifest-honister.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<manifest>
+  <default sync-j="2"/>
+
+  <remote fetch="https://git.openembedded.org/" name="oe"/>
+  <remote fetch="https://git.yoctoproject.org/git/" name="yocto"/>
+  <remote fetch="https://github.com" name="github"/>
+  <remote fetch="https://github.com/Igalia" name="igalia"/>
+  <remote fetch="https://gitlab.com" name="gitlab"/>
+  <remote fetch="http://code.qt.io/yocto" name="qt"/>
+
+  <project remote="oe" revision="honister" name="meta-openembedded" path="sources/meta-openembedded"/>
+  <project remote="oe" revision="honister" name="meta-python2" path="sources/meta-python2"/>
+
+  <project remote="yocto" revision="honister" name="poky" path="sources/poky"/>
+  <project remote="yocto" revision="master" name="meta-raspberrypi" path="sources/meta-raspberrypi"/>
+
+  <project remote="github" revision="psaavedra/add_honister" name="psaavedra/meta-gstreamer1.0.git" path="sources/meta-gstreamer1.0"/>
+
+  <project remote="qt" revision="honister" name="meta-qt5.git" path="sources/meta-qt5"/>
+
+  <project remote="igalia" revision="main" name="meta-webkit.git" path="sources/meta-webkit"/>
+</manifest>

--- a/.gitlab-ci/manifest/manifest-kirkstone.xml
+++ b/.gitlab-ci/manifest/manifest-kirkstone.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<manifest>
+  <default sync-j="2"/>
+
+  <remote fetch="https://git.openembedded.org/" name="oe"/>
+  <remote fetch="https://git.yoctoproject.org/git/" name="yocto"/>
+  <remote fetch="https://github.com" name="github"/>
+  <remote fetch="https://github.com/Igalia" name="igalia"/>
+  <remote fetch="https://gitlab.com" name="gitlab"/>
+  <remote fetch="http://code.qt.io/yocto" name="qt"/>
+
+  <project remote="oe" revision="master" name="meta-openembedded" path="sources/meta-openembedded"/>
+  <project remote="oe" revision="master" name="meta-python2" path="sources/meta-python2"/>
+
+  <project remote="yocto" revision="master" name="poky" path="sources/poky"/>
+  <project remote="yocto" revision="master" name="meta-raspberrypi" path="sources/meta-raspberrypi"/>
+
+  <project remote="github" revision="psaavedra/add_kirkstone" name="psaavedra/meta-gstreamer1.0.git" path="sources/meta-gstreamer1.0"/>
+
+  <project remote="qt" revision="master" name="meta-qt5.git" path="sources/meta-qt5"/>
+
+  <project remote="igalia" revision="main" name="meta-webkit.git" path="sources/meta-webkit"/>
+</manifest>

--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -16,5 +16,5 @@ BBFILE_PRIORITY_webkit = "7"
 # do not error out on bbappends for missing recipes
 BB_DANGLINGAPPENDS_WARNONLY = "true"
 
-# Support the current actively  maintained Yocto releases
-LAYERSERIES_COMPAT_webkit = "dunfell gatesgarth hardknott"
+# Support from the current actively maintained LTS Yocto release
+LAYERSERIES_COMPAT_webkit = "dunfell gatesgarth hardknott honister kirkstone"


### PR DESCRIPTION
* manifest: Replace OSSystems/meta-gstreamer1.0.git with psaavedra/meta-gstreamer1.0.git because the first one still doesn't support honister
* ci: update .gitlab-ci.yml tasks to honister
* ci: Add the honister Yocto release manifest


## Release Process

### List of task to do during a release:

1. The Release Process starts once the new Yocto release is released
1. Create a new Pull Request from the `main` branch to work in the required adaptations in layer to make it work with the new stable release
1. Create new milestone using this schema: `<Year&Month yocto release date>_<yocto release number>_<yocto release name>`
1. In the Pull Request, add the compatibility mark is added in the `conf/layer.conf` 
   1. We will try to keep the compatibility and the support in master/main for the latest 4 releases
   1. Other releases not matching with this criteria will be removed from the `LAYERSERIES_COMPAT` variable.
1. In the Pull Request, update the Yocto release name references with the new release name (this includes the CI files)
1. Once the Pull Request passes the CI tasks:
   1. Create a new branch from the `main` branch and named as the old-stable branch name
   1. Integrate the Pull Request in `main` (**fast-forward-merge**)
   1. Close the current milestone associated to the *old-stable* branch (the name should include the name of the already *old-stable* Yocto Release)