### PR TITLE
webkitgtk,wpewebkit: Bump up version to 2.32.4

### DIFF
--- a/recipes-browser/webkitgtk/webkitgtk_2.32.4.bb
+++ b/recipes-browser/webkitgtk/webkitgtk_2.32.4.bb
@@ -15,7 +15,7 @@ DEPENDS = "zlib libsoup-2.4 curl libxml2 cairo libxslt libidn \
 SRC_URI = "https://www.webkitgtk.org/releases/webkitgtk-${PV}.tar.xz;name=tarball \
            file://0001-MiniBrowser-Fix-reproduciblity.patch;name=minibrowser \
            "
-SRC_URI[tarball.sha256sum] = "c1f496f5ac654efe4cef62fbd4f2fbeeef265a07c5e7419e5d2900bfeea52cbc"
+SRC_URI[tarball.sha256sum] = "00ce2d3f798d7bc5e9039d9059f0c3c974d51de38c8b716f00e94452a177d3fd"
 SRC_URI[minibrowser.sha256sum] = "5729da9f7379ddc4e669f4c80d60d38bef8e84f7e0146dc319a63061cee4ceeb"
 
 RRECOMMENDS_${PN} = "${PN}-bin \

--- a/recipes-browser/wpewebkit/wpewebkit_2.32.4.bb
+++ b/recipes-browser/wpewebkit/wpewebkit_2.32.4.bb
@@ -7,7 +7,7 @@ SRC_URI = "\
     https://wpewebkit.org/releases/${BPN}-${PV}.tar.xz;name=tarball \
 "
 
-SRC_URI[tarball.sha256sum] = "859bd1bbe51026aecfb2b6f5c8c024d88fb69ac6fcdc74c788c9fbe9499d740d"
+SRC_URI[tarball.sha256sum] = "381f1422cbc319db1aa42dda48de39590ed90ac3bec6b81ec83f3f2cae5c3eeb"
 
 DEPENDS += " libwpe"
 RCONFLICTS_${PN} = "libwpe (< 1.4) wpebackend-fdo (< 1.6)"


### PR DESCRIPTION
* Do not append .asc extension to downloaded text/plain files.
* Fix several crashes and rendering issues

Security Advisory:

* Several vulnerabilities were discovered in WebKitGTK and WPE WebKit.
* https://webkitgtk.org/security/WSA-2021-0005.html

CVE-2021-30858
    Versions affected: WebKitGTK and WPE WebKit before 2.32.4.
    Credit to an anonymous researcher.
    Impact: Processing maliciously crafted web content may lead to
    arbitrary code execution. Apple is aware of a report that this issue
    may have been actively exploited. Description: A use after free
    issue was addressed with improved memory management.