### PR TITLE
Prefer DejaVu instead of Bitstream Vera fonts

### DIFF
--- a/recipes-browser/packagegroups/packagegroup-wpewebkit-depends.bb
+++ b/recipes-browser/packagegroups/packagegroup-wpewebkit-depends.bb
@@ -234,7 +234,9 @@ RDEPENDS_packagegroup-wpewebkit-depends-video = " \
 RDEPENDS_packagegroup-wpewebkit-depends-extra = " \
     ca-certificates \
     shared-mime-info \
-    ttf-bitstream-vera \
+    ttf-dejavu-sans \
+    ttf-dejavu-sans-mono \
+    ttf-dejavu-serif \
     gstreamer1.0-plugins-base-meta \
     gstreamer1.0-plugins-good-meta \
     gstreamer1.0-plugins-bad-meta \

--- a/recipes-browser/webkitgtk/webkitgtk_2.34.1.bb
+++ b/recipes-browser/webkitgtk/webkitgtk_2.34.1.bb
@@ -19,7 +19,9 @@ SRC_URI[tarball.sha256sum] = "443c1316705de024741748e85fe32324d299d9ee68e6feb340
 RRECOMMENDS_${PN} = "${PN}-bin \
                      ca-certificates \
                      shared-mime-info \
-                     ttf-bitstream-vera \
+                     ttf-dejavu-sans \
+                     ttf-dejavu-sans-mono \
+                     ttf-dejavu-serif \
                      ${@bb.utils.contains('PACKAGECONFIG', 'video', 'gstreamer1.0-plugins-base-meta gstreamer1.0-plugins-good-meta gstreamer1.0-plugins-bad-meta', '', d)} \
                      "
 RRECOMMENDS_${PN}-bin = "adwaita-icon-theme librsvg-gtk"

--- a/recipes-browser/wpewebkit/wpewebkit.inc
+++ b/recipes-browser/wpewebkit/wpewebkit.inc
@@ -164,7 +164,9 @@ RDEPENDS_${PN} += " \
 RRECOMMENDS_${PN} += " \
     ca-certificates \
     shared-mime-info \
-    ttf-bitstream-vera \
+    ttf-dejavu-sans \
+    ttf-dejavu-sans-mono \
+    ttf-dejavu-serif \
     ${PN}-web-inspector-plugin \
     ${PN}-qtwpe-qml-plugin \
     ${@bb.utils.contains('PACKAGECONFIG', 'video', 'gstreamer1.0-plugins-base-meta gstreamer1.0-plugins-good-meta gstreamer1.0-plugins-bad-meta', '', d)} \


### PR DESCRIPTION
Prefer the [DejaVu fonts](https://dejavu-fonts.github.io/), which are derived from Vera and add better Unicode coverage, which means they are more suitable as fallback fonts.