### PR TITLE
wpewebkit: tweak runtime dependencies/recommendations

### DIFF
--- a/recipes-browser/wpewebkit/wpewebkit.inc
+++ b/recipes-browser/wpewebkit/wpewebkit.inc
@@ -139,6 +139,7 @@ ARM_INSTRUCTION_SET_armv7ve = "thumb"
 RDEPENDS_${PN} += " \
     libgles2 \
     virtual/wpebackend \
+    ${@bb.utils.contains('PACKAGECONFIG', 'remote-inspector', '${PN}-web-inspector-plugin', '', d)} \
     ${@bb.utils.contains('PACKAGECONFIG', 'mediasource', 'gstreamer1.0-plugins-good-isomp4', '', d)} \
     ${@bb.utils.contains('PACKAGECONFIG', 'webaudio', 'gstreamer1.0-plugins-good-wavparse', '', d)} \
     ${@bb.utils.contains('PACKAGECONFIG', 'gst_gl', 'gstreamer1.0-plugins-base-opengl', '', d)} \
@@ -160,14 +161,16 @@ RDEPENDS_${PN} += " \
                                                     ', '', d)} \
 "
 
+RDEPENDS_${PN}-web-inspector-plugin += " \
+    shared-mime-info \
+"
+
 # Extra runtime recommends
 RRECOMMENDS_${PN} += " \
     ca-certificates \
-    shared-mime-info \
     ttf-dejavu-sans \
     ttf-dejavu-sans-mono \
     ttf-dejavu-serif \
-    ${PN}-web-inspector-plugin \
     ${PN}-qtwpe-qml-plugin \
     ${@bb.utils.contains('PACKAGECONFIG', 'video', 'gstreamer1.0-plugins-base-meta gstreamer1.0-plugins-good-meta gstreamer1.0-plugins-bad-meta', '', d)} \
 "


### PR DESCRIPTION
The remote inspector support has a hard requirement on the plugin, and the plugin hard-requires shared-mime-info or otherwise resources served by the remote inspector won't include a Content-Type header and the client will fail to load them.

Reflect the above by making wpewebkit-web-inspector-plugin have a runtime dependency on shared-mime-info, and then making wpewebkit depend on wpewebkit-web-inspector-plugin when remote-inspector is enabled in PACKAGECONFIG.

This PR is a rebase of https://github.com/Igalia/meta-webkit/pull/318