### PR TITLE
mesa: conditionally add patch for releases that need it

### DIFF
--- a/recipes-graphics/mesa/mesa_%.bbappend
+++ b/recipes-graphics/mesa/mesa_%.bbappend
@@ -1,0 +1,8 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
+
+python () {
+    version = d.getVar('PV')
+    if bb.utils.vercmp_string_op(version, "21.0.3", ">=") and \
+            bb.utils.vercmp_string_op(version, "21.2.1", "<="):
+                d.appendVar('SRC_URI', ' file://0001-gallium-dri-Make-YUV-formats-we-re-going-to-emulate-.patch')
+}

--- a/recipes-graphics/mesa/mesa_21.0.3.bbappend
+++ b/recipes-graphics/mesa/mesa_21.0.3.bbappend
@@ -1,4 +1,0 @@
-FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
-
-SRC_URI += "file://0001-gallium-dri-Make-YUV-formats-we-re-going-to-emulate-.patch"
-

--- a/recipes-graphics/mesa/mesa_21.2.1.bbappend
+++ b/recipes-graphics/mesa/mesa_21.2.1.bbappend
@@ -1,4 +1,0 @@
-FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
-
-SRC_URI += "file://0001-gallium-dri-Make-YUV-formats-we-re-going-to-emulate-.patch"
-


### PR DESCRIPTION
Conditionally add a patch to `SRC_URI` for those Yocto releases known to have affected Mesa versions. This avoids warnings in all other versions by not being specific about the Mesa version being matched.
