### PR TITLE
Fix compiler issue with the libyuv library in libwebrtc

### DIFF
--- a/recipes-browser/wpewebkit/wpewebkit/0002-libyuv-gcc-issue.patch
+++ b/recipes-browser/wpewebkit/wpewebkit/0002-libyuv-gcc-issue.patch
@@ -1,0 +1,92 @@
+diff --git a/Source/ThirdParty/libwebrtc/Source/third_party/libyuv/source/row_neon64.cc b/Source/ThirdParty/libwebrtc/Source/third_party/libyuv/source/row_neon64.cc
+index da7e3c7cd415..b9fafd8d21fa 100644
+--- a/Source/ThirdParty/libwebrtc/Source/third_party/libyuv/source/row_neon64.cc
++++ b/Source/ThirdParty/libwebrtc/Source/third_party/libyuv/source/row_neon64.cc
+@@ -1726,7 +1726,7 @@ void ARGBToAB64Row_NEON(const uint8_t* src_argb,
+       : "+r"(src_argb),          // %0
+         "+r"(dst_ab64),          // %1
+         "+r"(width)              // %2
+-      : "m"(kShuffleARGBToABGR)  // %3
++      : "Q"(kShuffleARGBToABGR)  // %3
+       : "cc", "memory", "v0", "v1", "v2", "v3", "v4");
+ }
+ 
+@@ -1750,7 +1750,7 @@ void AR64ToARGBRow_NEON(const uint16_t* src_ar64,
+       : "+r"(src_ar64),          // %0
+         "+r"(dst_argb),          // %1
+         "+r"(width)              // %2
+-      : "m"(kShuffleAR64ToARGB)  // %3
++      : "Q"(kShuffleAR64ToARGB)  // %3
+       : "cc", "memory", "v0", "v1", "v2", "v3", "v4");
+ }
+ 
+@@ -1774,7 +1774,7 @@ void AB64ToARGBRow_NEON(const uint16_t* src_ab64,
+       : "+r"(src_ab64),          // %0
+         "+r"(dst_argb),          // %1
+         "+r"(width)              // %2
+-      : "m"(kShuffleAB64ToARGB)  // %3
++      : "Q"(kShuffleAB64ToARGB)  // %3
+       : "cc", "memory", "v0", "v1", "v2", "v3", "v4");
+ }
+ 
+diff --git a/Source/ThirdParty/libwebrtc/Source/third_party/libyuv/source/scale_neon64.cc b/Source/ThirdParty/libwebrtc/Source/third_party/libyuv/source/scale_neon64.cc
+index 8656fec7fa9c..9f9636e646d3 100644
+--- a/Source/ThirdParty/libwebrtc/Source/third_party/libyuv/source/scale_neon64.cc
++++ b/Source/ThirdParty/libwebrtc/Source/third_party/libyuv/source/scale_neon64.cc
+@@ -601,8 +601,8 @@ void ScaleRowUp2_Bilinear_NEON(const uint8_t* src_ptr,
+       "umlal       v4.8h, v1.8b, v31.8b          \n"  // 3*near+far (2, odd)
+       "umlal       v5.8h, v0.8b, v31.8b          \n"  // 3*near+far (2, even)
+ 
+-      "mov         v0.8h, v4.8h                  \n"
+-      "mov         v1.8h, v5.8h                  \n"
++      "mov         v0.16b, v4.16b                \n"
++      "mov         v1.16b, v5.16b                \n"
+       "mla         v4.8h, v2.8h, v30.8h          \n"  // 9 3 3 1 (1, odd)
+       "mla         v5.8h, v3.8h, v30.8h          \n"  // 9 3 3 1 (1, even)
+       "mla         v2.8h, v0.8h, v30.8h          \n"  // 9 3 3 1 (2, odd)
+@@ -642,7 +642,7 @@ void ScaleRowUp2_Linear_12_NEON(const uint16_t* src_ptr,
+       "ld1         {v1.8h}, [%1], #16            \n"  // 12345678 (16b)
+       "prfm        pldl1keep, [%0, 448]          \n"  // prefetch 7 lines ahead
+ 
+-      "mov         v2.8h, v0.8h                  \n"
++      "mov         v2.16b, v0.16b                \n"
+       "mla         v0.8h, v1.8h, v31.8h          \n"  // 3*near+far (odd)
+       "mla         v1.8h, v2.8h, v31.8h          \n"  // 3*near+far (even)
+ 
+@@ -679,7 +679,7 @@ void ScaleRowUp2_Bilinear_12_NEON(const uint16_t* src_ptr,
+       "ld1         {v3.8h}, [%2], #16            \n"  // 12345678 (16b)
+       "prfm        pldl1keep, [%0, 448]          \n"  // prefetch 7 lines ahead
+ 
+-      "mov         v0.8h, v2.8h                  \n"
++      "mov         v0.16b, v2.16b                \n"
+       "mla         v2.8h, v3.8h, v31.8h          \n"  // 3*near+far (odd)
+       "mla         v3.8h, v0.8h, v31.8h          \n"  // 3*near+far (even)
+ 
+@@ -687,12 +687,12 @@ void ScaleRowUp2_Bilinear_12_NEON(const uint16_t* src_ptr,
+       "ld1         {v5.8h}, [%3], #16            \n"  // 12345678 (16b)
+       "prfm        pldl1keep, [%1, 448]          \n"  // prefetch 7 lines ahead
+ 
+-      "mov         v0.8h, v4.8h                  \n"
++      "mov         v0.16b, v4.16b                \n"
+       "mla         v4.8h, v5.8h, v31.8h          \n"  // 3*near+far (odd)
+       "mla         v5.8h, v0.8h, v31.8h          \n"  // 3*near+far (even)
+ 
+-      "mov         v0.8h, v4.8h                  \n"
+-      "mov         v1.8h, v5.8h                  \n"
++      "mov         v0.16b, v4.16b                \n"
++      "mov         v1.16b, v5.16b                \n"
+       "mla         v4.8h, v2.8h, v31.8h          \n"  // 9 3 3 1 (1, odd)
+       "mla         v5.8h, v3.8h, v31.8h          \n"  // 9 3 3 1 (1, even)
+       "mla         v2.8h, v0.8h, v31.8h          \n"  // 9 3 3 1 (2, odd)
+@@ -887,8 +887,8 @@ void ScaleUVRowUp2_Bilinear_NEON(const uint8_t* src_ptr,
+       "umlal       v4.8h, v1.8b, v31.8b          \n"  // 3*near+far (2, odd)
+       "umlal       v5.8h, v0.8b, v31.8b          \n"  // 3*near+far (2, even)
+ 
+-      "mov         v0.8h, v4.8h                  \n"
+-      "mov         v1.8h, v5.8h                  \n"
++      "mov         v0.16b, v4.16b                \n"
++      "mov         v1.16b, v5.16b                \n"
+       "mla         v4.8h, v2.8h, v30.8h          \n"  // 9 3 3 1 (1, odd)
+       "mla         v5.8h, v3.8h, v30.8h          \n"  // 9 3 3 1 (1, even)
+       "mla         v2.8h, v0.8h, v30.8h          \n"  // 9 3 3 1 (2, odd)
+       

--- a/recipes-browser/wpewebkit/wpewebkit_2.34.1.bb
+++ b/recipes-browser/wpewebkit/wpewebkit_2.34.1.bb
@@ -13,7 +13,10 @@ SRC_URI[tarball.sha256sum] = "cb336986341be9c3a9b1ca2c18de0d29d90ae4e77b9967a6f6
 DEPENDS += " libwpe"
 RCONFLICTS:${PN} = "libwpe (< 1.8) wpebackend-fdo (< 1.10)"
 
-SRC_URI:class-devupstream = "git://git.webkit.org/WebKit.git;branch=master"
+SRC_URI_class-devupstream = "\
+    git://git.webkit.org/WebKit.git;branch=master \
+    file://0002-libyuv-gcc-issue.patch \
+"
 # WPE 2.34.X branch was forked from the main branch in this commit
 SRCREV:class-devupstream = "30c41fe654d9556a5681663166c1461132326ff7"
 


### PR DESCRIPTION
When building the wpewebkit from the git-source together with libwebrtc for imx8 there is a compiling Issue within libyuv. This is already fixed, but not in the currently used version. I created a patch for it.

Please have a look here:
https://chromium-review.googlesource.com/c/libyuv/libyuv/+/2922146
and here:
https://chromium-review.googlesource.com/c/libyuv/libyuv/+/2922147