### PR TITLE
webkitgtk,wpewebkit: bump to version 2.34.3

### DIFF
--- a/recipes-browser/webkitgtk/webkitgtk_2.34.3.bb
+++ b/recipes-browser/webkitgtk/webkitgtk_2.34.3.bb
@@ -16,7 +16,7 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 SRC_URI = " \
     https://www.webkitgtk.org/releases/webkitgtk-${PV}.tar.xz;name=tarball \
 "
-SRC_URI[tarball.sha256sum] = "584677d6e7cae12e27cdcc8e05b4cf73b54849a24afc3d7a40cec91016deff00"
+SRC_URI[tarball.sha256sum] = "0d2f37aa32e21a36e4dd5a5ce7ae5ce27435c29d6803b962b8c90cb0cc49c52d"
 
 RRECOMMENDS:${PN} = "${PN}-bin \
                      ca-certificates \

--- a/recipes-browser/wpewebkit/wpewebkit_2.34.3.bb
+++ b/recipes-browser/wpewebkit/wpewebkit_2.34.3.bb
@@ -7,7 +7,7 @@ SRC_URI = "\
     https://wpewebkit.org/releases/${BPN}-${PV}.tar.xz;name=tarball \
 "
 
-SRC_URI[tarball.sha256sum] = "b1a3733c2d486c4da27f9636ccc39947da7d84258cd7a24a6fb0b842c9595c0b"
+SRC_URI[tarball.sha256sum] = "c35de4bfce35c81cbd6c1da27879b4ea33e20bd51d750ce296a4d100d45f40fc"
 
 DEPENDS += " libwpe"
 RCONFLICTS:${PN} = "libwpe (< 1.8) wpebackend-fdo (< 1.10)"


### PR DESCRIPTION
    
This is a bug fix release in the stable 2.34 series.

Release notes:

* Make audio tools (like mixers) display the actual name of the application
  producing sound, instead of a generic one.
* Fix several crashes and rendering issues.
    
Ref:

* https://webkitgtk.org/2021/12/20/webkitgtk2.34.3-released.html
* https://wpewebkit.org/release/wpewebkit-2.34.3.html
