### PR TITLE
webkitgtk,wpewebkit: bump to version 2.34.4

### DIFF
--- a/recipes-browser/webkitgtk/webkitgtk_2.34.4.bb
+++ b/recipes-browser/webkitgtk/webkitgtk_2.34.4.bb
@@ -16,7 +16,7 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 SRC_URI = " \
     https://www.webkitgtk.org/releases/webkitgtk-${PV}.tar.xz;name=tarball \
 "
-SRC_URI[tarball.sha256sum] = "0d2f37aa32e21a36e4dd5a5ce7ae5ce27435c29d6803b962b8c90cb0cc49c52d"
+SRC_URI[tarball.sha256sum] = "975f5019199ba7699191835cf75e01a18b94e3bcd0107da7389d4ddcb1aba406"
 
 RRECOMMENDS:${PN} = "${PN}-bin \
                      ca-certificates \

--- a/recipes-browser/wpewebkit/wpewebkit_2.34.4.bb
+++ b/recipes-browser/wpewebkit/wpewebkit_2.34.4.bb
@@ -7,7 +7,7 @@ SRC_URI = "\
     https://wpewebkit.org/releases/${BPN}-${PV}.tar.xz;name=tarball \
 "
 
-SRC_URI[tarball.sha256sum] = "c35de4bfce35c81cbd6c1da27879b4ea33e20bd51d750ce296a4d100d45f40fc"
+SRC_URI[tarball.sha256sum] = "3653ba42dbe22a4e6751b3f7cab8d2ebb2db5b7654c5d135a2f9bedf94778cee"
 
 DEPENDS += " libwpe"
 RCONFLICTS:${PN} = "libwpe (< 1.8) wpebackend-fdo (< 1.10)"


### PR DESCRIPTION
```
    webkitgtk: bump to version 2.34.4
    
    This is a bug fix release in the stable 2.34 series.
    
    Release notes:
    
    * Fix several crashes and rendering issues.
    
    Ref: https://webkitgtk.org/2022/01/21/webkitgtk2.34.4-released.html
```

```
    wpewebkit: bump to version 2.34.4
    
    This is a bug fix release in the stable 2.34 series.
    
    Release notes:
    
    * Fix several crashes and rendering issues.
    
    Ref: https://wpewebkit.org/release/wpewebkit-2.34.4.html
```
