### PR TITLE
Bump up wpewebkit,webkitgtk to version 2.34.5

### DIFF
--- a/recipes-browser/webkitgtk/webkitgtk_2.34.5.bb
+++ b/recipes-browser/webkitgtk/webkitgtk_2.34.5.bb
@@ -16,7 +16,7 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 SRC_URI = " \
     https://www.webkitgtk.org/releases/webkitgtk-${PV}.tar.xz;name=tarball \
 "
-SRC_URI[tarball.sha256sum] = "975f5019199ba7699191835cf75e01a18b94e3bcd0107da7389d4ddcb1aba406"
+SRC_URI[tarball.sha256sum] = "68930643af7a47a3af05f46d66e784422433753dab335d3282f319a85a5629b4"
 
 RRECOMMENDS:${PN} = "${PN}-bin \
                      ca-certificates \

--- a/recipes-browser/wpewebkit/wpewebkit_2.34.5.bb
+++ b/recipes-browser/wpewebkit/wpewebkit_2.34.5.bb
@@ -7,7 +7,7 @@ SRC_URI = "\
     https://wpewebkit.org/releases/${BPN}-${PV}.tar.xz;name=tarball \
 "
 
-SRC_URI[tarball.sha256sum] = "3653ba42dbe22a4e6751b3f7cab8d2ebb2db5b7654c5d135a2f9bedf94778cee"
+SRC_URI[tarball.sha256sum] = "0ef187cdcb83dbe9e7b2870f43543b68766ea3535fe8b056866e8e1d3ef02bc1"
 
 DEPENDS += " libwpe"
 RCONFLICTS:${PN} = "libwpe (< 1.8) wpebackend-fdo (< 1.10)"


### PR DESCRIPTION
Release notes:
    
    * Improve VP8 codec selection when using GStreamer 1.20.
    * Fix connecting to the accessibility bus when using the Bubblewrap sandbox.
    * Fix links being incorrectly activated when starting a pinch zoom gesture.
    * Fix touch-based scrolling.
    * Fix the build with recent toolchains based on GCC 12 and on older ones as included e.g. in Ubuntu 18.04.
    * Fix the build with ICU 60, version 61 is no longer required.
    * Fix several crashes and rendering issues.
