### PR TITLE
wpewebkit,webkitgtk: bump to version 2.34.6

### DIFF
--- a/recipes-browser/webkitgtk/webkitgtk_2.34.6.bb
+++ b/recipes-browser/webkitgtk/webkitgtk_2.34.6.bb
@@ -16,7 +16,7 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 SRC_URI = " \
     https://www.webkitgtk.org/releases/webkitgtk-${PV}.tar.xz;name=tarball \
 "
-SRC_URI[tarball.sha256sum] = "68930643af7a47a3af05f46d66e784422433753dab335d3282f319a85a5629b4"
+SRC_URI[tarball.sha256sum] = "6bc8fd034aad0432a2459ce4fc7ee25ad65a4924c618bf8d93b52b0c1a84c1f6"
 
 RRECOMMENDS:${PN} = "${PN}-bin \
                      ca-certificates \

--- a/recipes-browser/wpewebkit/wpewebkit_2.34.6.bb
+++ b/recipes-browser/wpewebkit/wpewebkit_2.34.6.bb
@@ -7,7 +7,7 @@ SRC_URI = "\
     https://wpewebkit.org/releases/${BPN}-${PV}.tar.xz;name=tarball \
 "
 
-SRC_URI[tarball.sha256sum] = "0ef187cdcb83dbe9e7b2870f43543b68766ea3535fe8b056866e8e1d3ef02bc1"
+SRC_URI[tarball.sha256sum] = "301e895c8ed08ce7dccef3192b972f2ccfc2020463244c64069a636f2b05265f"
 
 DEPENDS += " libwpe"
 RCONFLICTS:${PN} = "libwpe (< 1.8) wpebackend-fdo (< 1.10)"


### PR DESCRIPTION
This is a bug fix release in the stable 2.34 series.

Release notes:

* Fix accessibility not working when the Bubblewrap sandbox is enabled.
* Fix the build in a number of situations where the main OpenGL library
  is not called libGL or libgl, as is the case on systems that use
  libglvnd.
* Fix several crashes and rendering issues.

Ref: https://wpewebkit.org/release/wpewebkit-2.34.6.html