### PR TITLE
[backport] cog: bump to version 0.12.2

### DIFF
--- a/recipes-browser/cog/cog_0.12.2.bb
+++ b/recipes-browser/cog/cog_0.12.2.bb
@@ -2,7 +2,7 @@ require cog.inc
 require conf/include/devupstream.inc
 
 
-SRC_URI[sha256sum] = "aad413a8aaf15d400d70f9c909a28b92b138f7b0c0d825978de8788d0d75208a"
+SRC_URI[sha256sum] = "ccebdc1f216b698d1e780d3a71617bec1d2cd95ac5c9da59f563372463d97ed7"
 
 # Avalilable from 0.10.X
 PACKAGECONFIG[headless] = "-DCOG_PLATFORM_HEADLESS=ON,-DCOG_PLATFORM_HEADLESS=OFF,wpebackend-fdo"
@@ -13,6 +13,6 @@ PACKAGECONFIG[wl] = "-DCOG_PLATFORM_WL=ON,-DCOG_PLATFORM_WL=OFF,wpebackend-fdo"
 PACKAGECONFIG_class-devupstream ?= " ${@bb.utils.contains('PREFERRED_PROVIDER_virtual/wpebackend', 'wpebackend-fdo', 'fdo wl drm', '', d)} "
 
 SRC_URI_class-devupstream = "git://github.com/Igalia/cog.git;protocol=https;branch=cog-0.12"
-SRCREV_class-devupstream = "15902180647b66e63f005471c2f2d375f2cca831"
+SRCREV_class-devupstream = "758c40e9e09940136d892866078477eb0467c709"
 
 RDEPENDS_${PN} += "wpewebkit (>= 2.34)"


### PR DESCRIPTION
Release notes: https://wpewebkit.org/release/cog-0.12.2.html