### PR TITLE
Create new cfg for next Yocto release, rename LICENSE_FLAGS_WHITELIST…

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -41,7 +41,7 @@ kirkstone-raspberrypi3-mesa-weston-wpe-2.34:
   allow_failure: true
   variables:
     MANIFEST: .gitlab-ci/manifest/manifest-kirkstone.xml
-    SOURCE: raspberrypi3-mesa-wpe-2.34 raspberrypi3-mesa poky layers.python2.raspberrypi.webkit conf_v2.wpe-2_34
+    SOURCE: raspberrypi3-mesa-wpe-2.34 raspberrypi3-mesa poky layers.python2.raspberrypi.webkit conf_v3.wpe-2_34
 
 honister-raspberrypi3-mesa-weston-gtk:
   extends:

--- a/.gitlab-ci/template/presets/conf_v3.conf
+++ b/.gitlab-ci/template/presets/conf_v3.conf
@@ -1,0 +1,28 @@
+PACKAGE_CLASSES ?= "package_rpm"
+
+#
+# Additional image features
+#
+# The following is a list of additional classes to use when building images which
+# enable extra features. Some available options which can be included in this variable
+# are:
+#   - 'buildstats' collect build statistics
+USER_CLASSES ?= "buildstats"
+PATCHRESOLVE = "noop"
+BB_DISKMON_DIRS ??= "\
+    STOPTASKS,${TMPDIR},1G,100K \
+    STOPTASKS,${DL_DIR},1G,100K \
+    STOPTASKS,${SSTATE_DIR},1G,100K \
+    STOPTASKS,/tmp,100M,100K \
+    ABORT,${TMPDIR},100M,1K \
+    ABORT,${DL_DIR},100M,1K \
+    ABORT,${SSTATE_DIR},100M,1K \
+    ABORT,/tmp,10M,1K"
+PACKAGECONFIG:append:pn-qemu-native = " sdl"
+PACKAGECONFIG:append:pn-nativesdk-qemu = " sdl"
+CONF_VERSION = "2"
+
+DL_DIR ?= "${BSPDIR}/downloads/"
+ACCEPT_FSL_EULA = "1"
+
+LICENSE_FLAGS_ACCEPTED="commercial"


### PR DESCRIPTION
…->_ACCEPTED

This is required in future releases (kirkstone):

  $ bitbake $BITBAKE_TARGET
  ERROR: Variable LICENSE_FLAGS_WHITELIST has been renamed to
  	 LICENSE_FLAGS_ACCEPTED (file:
	 /.../builds/raspberrypi3-mesa-wpe-2.34/conf/presets/conf_v2.conf
         line: 28)

The rest of the contents of "conf_v3.conf" are the same as "v2".