### PR TITLE
wpewebkit: bump version to 2.34.7

### DIFF
--- a/recipes-browser/wpewebkit/wpewebkit/0001-WPE-Build-ANGLE-with-the-EGL_NO_PLATFORM_SPECIFIC_TY.patch
+++ b/recipes-browser/wpewebkit/wpewebkit/0001-WPE-Build-ANGLE-with-the-EGL_NO_PLATFORM_SPECIFIC_TY.patch
@@ -1,0 +1,24 @@
+From b74564f97c395bb2ce32731481813fa1b192adfe Mon Sep 17 00:00:00 2001
+From: Pablo Saavedra <psaavedra@igalia.com>
+Date: Mon, 11 Apr 2022 11:07:41 +0200
+Subject: [PATCH] [WPE] Build ANGLE with the EGL_NO_PLATFORM_SPECIFIC_TYPES
+ define https://bugs.webkit.org/show_bug.cgi?id=239039
+
+Specify the EGL_NO_PLATFORM_SPECIFIC_TYPES define when building ANGLE
+subproject for the GTK and WPE ports. This should avoid searching for
+platform-specific headers that might not be available at all during
+build, e.g. the X11 headers which are used by default on UNIX platforms.
+---
+ Source/ThirdParty/ANGLE/PlatformWPE.cmake | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Source/ThirdParty/ANGLE/PlatformWPE.cmake b/Source/ThirdParty/ANGLE/PlatformWPE.cmake
+index a4d0b959..8f5bff7f 100644
+--- a/Source/ThirdParty/ANGLE/PlatformWPE.cmake
++++ b/Source/ThirdParty/ANGLE/PlatformWPE.cmake
+@@ -1,4 +1,4 @@
+-list(APPEND ANGLE_DEFINITIONS ANGLE_PLATFORM_LINUX)
++list(APPEND ANGLE_DEFINITIONS ANGLE_PLATFORM_LINUX EGL_NO_PLATFORM_SPECIFIC_TYPES)
+ include(linux.cmake)
+ 
+ if (USE_OPENGL)

--- a/recipes-browser/wpewebkit/wpewebkit_2.34.7.bb
+++ b/recipes-browser/wpewebkit/wpewebkit_2.34.7.bb
@@ -6,7 +6,7 @@ SRC_URI = "\
     https://wpewebkit.org/releases/${BPN}-${PV}.tar.xz;name=tarball \
 "
 
-SRC_URI[tarball.sha256sum] = "301e895c8ed08ce7dccef3192b972f2ccfc2020463244c64069a636f2b05265f"
+SRC_URI[tarball.sha256sum] = "092659bf43e5bc6f2a5a7b8e612a39da5da56a04f41eacc716638f53a27c3412"
 
 DEPENDS += " libwpe"
 RCONFLICTS:${PN} = "libwpe (< 1.8) wpebackend-fdo (< 1.10)"

--- a/recipes-browser/wpewebkit/wpewebkit_2.36.0.bb
+++ b/recipes-browser/wpewebkit/wpewebkit_2.36.0.bb
@@ -3,9 +3,9 @@ require conf/include/devupstream.inc
 
 FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
-SRC_URI = "\
-    https://wpewebkit.org/releases/${BPN}-${PV}.tar.xz;name=tarball \
-"
+SRC_URI = "https://wpewebkit.org/releases/${BPN}-${PV}.tar.xz;name=tarball \
+           file://0001-WPE-Build-ANGLE-with-the-EGL_NO_PLATFORM_SPECIFIC_TY.patch \
+           "
 
 SRC_URI[tarball.sha256sum] = "096aa9f87d9bfbfc80f558388a86721cdcc508b42ddef10bd270aec9aee96d5a"
 


### PR DESCRIPTION
```
commit 77088643c1ba85da4dc08f53f5eda167cea9b52c (HEAD -> psaavedra/fixes, origin/psaavedra/fixes)
Author: Pablo Saavedra <psaavedra@igalia.com>
Date:   Mon Apr 11 11:27:44 2022 +0200

    wpewebkit: Fix build WPE no X11 headers present
    
    Upstream-Status: Submitted [https://bugs.webkit.org/show_bug.cgi?id=239039]
    Signed-off-by: Pablo Saavedra <psaavedra@igalia.com>

commit 8123c76442a161ede5770efc1b7575c37905e64a
Author: Pablo Saavedra <psaavedra@igalia.com>
Date:   Mon Apr 11 11:13:22 2022 +0200

    wpewebkit: Bump up version to 2.34.7
    
    * Fix several crashes and rendering issues.
    * Release notes: https://wpewebkit.org/release/wpewebkit-2.34.7.html


```