### PR TITLE
wpewebkit,webkitgtk: Bump up version to 2.36.2

### DIFF
--- a/recipes-browser/webkitgtk/webkitgtk/webkitgtk-0001-GTK-WPE-Build-ANGLE-with-the-EGL_NO_PLATFORM_SPECIFI.patch
+++ b/recipes-browser/webkitgtk/webkitgtk/webkitgtk-0001-GTK-WPE-Build-ANGLE-with-the-EGL_NO_PLATFORM_SPECIFI.patch
@@ -1,0 +1,39 @@
+From 32135a4af7c2ea1db2ea528df9af0a331ca88dba Mon Sep 17 00:00:00 2001
+From: "zan@falconsigh.net"
+ <zan@falconsigh.net@268f45cc-cd09-0410-ab3c-d52691b4dbfc>
+Date: Tue, 12 Apr 2022 06:34:44 +0000
+Subject: [PATCH] [GTK][WPE] Build ANGLE with the
+ EGL_NO_PLATFORM_SPECIFIC_TYPES define
+ https://bugs.webkit.org/show_bug.cgi?id=239039
+
+Reviewed by Adrian Perez de Castro.
+
+Specify the EGL_NO_PLATFORM_SPECIFIC_TYPES define when building ANGLE
+subproject for the GTK and WPE ports. This should avoid searching for
+platform-specific headers that might not be available at all during
+build, e.g. the X11 headers which are used by default on UNIX platforms.
+
+* PlatformGTK.cmake:
+* PlatformWPE.cmake:
+
+Signed-off-by: Adrian Perez de Castro <aperez@igalia.com>
+Upstream status: https://bugs.webkit.org/show_bug.cgi?id=239039
+---
+ Source/ThirdParty/ANGLE/ChangeLog         | 15 +++++++++++++++
+ Source/ThirdParty/ANGLE/PlatformGTK.cmake |  2 +-
+ Source/ThirdParty/ANGLE/PlatformWPE.cmake |  2 +-
+ 3 files changed, 17 insertions(+), 2 deletions(-)
+
+diff --git a/Source/ThirdParty/ANGLE/PlatformGTK.cmake b/Source/ThirdParty/ANGLE/PlatformGTK.cmake
+index 6d5287f1900..edf72f99dcd 100644
+--- a/Source/ThirdParty/ANGLE/PlatformGTK.cmake
++++ b/Source/ThirdParty/ANGLE/PlatformGTK.cmake
+@@ -1,4 +1,4 @@
+-list(APPEND ANGLE_DEFINITIONS ANGLE_PLATFORM_LINUX USE_SYSTEM_EGL)
++list(APPEND ANGLE_DEFINITIONS ANGLE_PLATFORM_LINUX EGL_NO_PLATFORM_SPECIFIC_TYPES USE_SYSTEM_EGL)
+ include(linux.cmake)
+ 
+ if (USE_OPENGL)
+-- 
+2.36.1
+

--- a/recipes-browser/webkitgtk/webkitgtk_2.36.2.bb
+++ b/recipes-browser/webkitgtk/webkitgtk_2.36.2.bb
@@ -15,8 +15,9 @@ DEPENDS = "zlib libsoup-2.4 curl libxml2 cairo libxslt libidn \
 FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 SRC_URI = " \
     https://www.webkitgtk.org/releases/webkitgtk-${PV}.tar.xz;name=tarball \
+    file://webkitgtk-0001-GTK-WPE-Build-ANGLE-with-the-EGL_NO_PLATFORM_SPECIFI.patch \
 "
-SRC_URI[tarball.sha256sum] = "b877cca1f105235f5dd57c7ac2b2c2be3c6b691ff444f93925c7254cf156c64d"
+SRC_URI[tarball.sha256sum] = "fe93bddb4a02c0e36f926efb6e81d28afd288b8824f6c5cf6a75cf40228e008e"
 
 RRECOMMENDS:${PN} = "${PN}-bin \
                      ca-certificates \

--- a/recipes-browser/wpewebkit/wpewebkit_2.36.2.bb
+++ b/recipes-browser/wpewebkit/wpewebkit_2.36.2.bb
@@ -7,7 +7,7 @@ SRC_URI = "https://wpewebkit.org/releases/${BPN}-${PV}.tar.xz;name=tarball \
            file://0001-WPE-Build-ANGLE-with-the-EGL_NO_PLATFORM_SPECIFIC_TY.patch \
            "
 
-SRC_URI[tarball.sha256sum] = "096aa9f87d9bfbfc80f558388a86721cdcc508b42ddef10bd270aec9aee96d5a"
+SRC_URI[tarball.sha256sum] = "959519562701e2005f2767a62e85977d6c3e65858709b376c89d8e33502febb9"
 
 DEPENDS += " libwpe"
 RCONFLICTS:${PN} = "libwpe (< 1.10) wpebackend-fdo (< 1.10)"


### PR DESCRIPTION
wpewebkit:
* Fix some pages showing empty content boxes when using threaded rendering.
* Fix the build with accessibility disabled.
* Fix the build with newer Ruby versions.
* Fix several crashes and rendering issues.
* Release notes: https://wpewebkit.org/release/wpewebkit-2.36.2.html

webkitgtk:
* Fix some pages showing empty content boxes when using GTK4.
* Fix the build with accessibility disabled.
* Fix the build with newer Ruby versions.
* Fix several crashes and rendering issues.
* Release notes: https://webkitgtk.org/2022/05/18/webkitgtk2.36.2-released.html