### PR TITLE
wpewebkit: add systemd build dependency for PACKAGECONFIG[systemd] (backport for Dunfell)

### DIFF
--- a/recipes-browser/wpewebkit/wpewebkit.inc
+++ b/recipes-browser/wpewebkit/wpewebkit.inc
@@ -46,7 +46,7 @@ PACKAGECONFIG[webrtc] = "-DENABLE_WEB_RTC=ON,-DENABLE_WEB_RTC=OFF,libvpx libeven
 PACKAGECONFIG[qtwpe] = "-DENABLE_WPE_QT_API=ON,-DENABLE_WPE_QT_API=OFF,qtbase-native qtbase qtdeclarative qtquickcontrols2 libepoxy wpebackend-fdo"
 PACKAGECONFIG[openjpeg] = "-DUSE_OPENJPEG=ON,-DUSE_OPENJPEG=OFF,openjpeg"
 PACKAGECONFIG[unified-builds] = "-DENABLE_UNIFIED_BUILDS=ON,-DENABLE_UNIFIED_BUILDS=OFF,"
-PACKAGECONFIG[systemd] = "-DUSE_SYSTEMD=ON,-DUSE_SYSTEMD=OFF,"
+PACKAGECONFIG[systemd] = "-DUSE_SYSTEMD=ON,-DUSE_SYSTEMD=OFF,systemd"
 PACKAGECONFIG[webxr] = "-DENABLE_WEBXR=ON,-DENABLE_WEBXR=OFF,"
 #TODO: Add recipe for openxr:
 #  url: github_com:KhronosGroup/OpenXR-SDK.git


### PR DESCRIPTION
Otherwise libsystemd might or might not be available, depending on other
PACKAGECONFIG options that might add it implicitly.

(cherry picked from commit 3eec26f6ee36a0397aff0848b1980697f5e1de83)

Signed-off-by: Bastian Krause <bst@pengutronix.de>
Signed-off-by: Joshua Watt <Joshua.Watt@garmin.com>