### PR TITLE
wpewebkit: Fix include gstreamer path on cross compiler toolchains 

### DIFF
--- a/recipes-browser/wpewebkit/wpewebkit/0001-Fix-include-path-gstreamer-on-cross-toolchain.patch
+++ b/recipes-browser/wpewebkit/wpewebkit/0001-Fix-include-path-gstreamer-on-cross-toolchain.patch
@@ -1,0 +1,52 @@
+From 53e91f50ed88c3c3016f9b5dd921a0f76a7f3fed Mon Sep 17 00:00:00 2001
+From: Pablo Saavedra <psaavedra@igalia.com>
+Date: Thu, 9 Jun 2022 22:32:39 +0200
+Subject: [PATCH] Fix include gstreamer path on cross compiler toolchains
+ https://bugs.webkit.org/show_bug.cgi?id=241483
+
+Reviewed by NOBODY (OOPS!).
+
+Set the include paths for the gstreamer components to the full path
+using the find_path(). This function relies in CMAKE_FIND_ROOT_PATH to
+find the right place where the includes they are. This fixes possible
+warnings/errors on cross toolchains using -Wpoison-system-directories
+and -Werror=poison-system-directories.
+
+* Source/cmake/FindGStreamer.cmake:
+---
+ Source/cmake/FindGStreamer.cmake | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+Upstream-Status: Submitted [https://github.com/WebKit/WebKit/pull/1428]
+
+diff --git a/Source/cmake/FindGStreamer.cmake b/Source/cmake/FindGStreamer.cmake
+index 9d97a4b5..27b50a1a 100644
+--- a/Source/cmake/FindGStreamer.cmake
++++ b/Source/cmake/FindGStreamer.cmake
+@@ -70,12 +70,20 @@ macro(FIND_GSTREAMER_COMPONENT _component_prefix _pkgconfig_name _library)
+     # ${includedir}/gstreamer-1.0 which remains correct. The issue here is that
+     # we don't rely on the `Cflags`, cmake fails to generate a proper
+     # `.._INCLUDE_DIRS` variable in this case. So we need to do it here...
++
++    # Populate the list initially from the _INCLUDE_DIRS result variable.
++    set(${_component_prefix}_INCLUDE_DIRS ${PC_${_component_prefix}_INCLUDE_DIRS})
++
+     set(_include_dir "${PC_${_component_prefix}_INCLUDEDIR}")
+     string(REGEX MATCH "(.*)/gstreamer-1.0" _dummy "${_include_dir}")
++
+     if ("${CMAKE_MATCH_1}" STREQUAL "")
+-        set(${_component_prefix}_INCLUDE_DIRS "${_include_dir}/gstreamer-1.0;${PC_${_component_prefix}_INCLUDE_DIRS}")
+-    else ()
+-        set(${_component_prefix}_INCLUDE_DIRS "${PC_${_component_prefix}_INCLUDE_DIRS}")
++        find_path(${_component_prefix}_RESOLVED_INCLUDEDIR NAMES "${_include_dir}/gstreamer-1.0")
++        # Only add the resolved path from `_INCLUDEDIR` if found.
++        if (${_component_prefix}_RESOLVED_INCLUDEDIR)
++            list(APPEND ${_component_prefix}_INCLUDE_DIRS
++                 "${${_component_prefix}_RESOLVED_INCLUDEDIR}")
++        endif ()
+     endif ()
+ 
+     find_library(${_component_prefix}_LIBRARIES
+-- 
+2.34.1
+

--- a/recipes-browser/wpewebkit/wpewebkit_2.36.3.bb
+++ b/recipes-browser/wpewebkit/wpewebkit_2.36.3.bb
@@ -4,6 +4,7 @@ require conf/include/devupstream.inc
 FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
 SRC_URI = "https://wpewebkit.org/releases/${BPN}-${PV}.tar.xz;name=tarball \
+           file://0001-Fix-include-path-gstreamer-on-cross-toolchain.patch \
            "
 
 SRC_URI[tarball.sha256sum] = "66275debca7497daff3a7826734cd56262a807adb76c5dccdf257c89968c2fc8"


### PR DESCRIPTION
Upstream issue: https://bugs.webkit.org/show_bug.cgi?id=241483 - https://github.com/WebKit/WebKit/pull/1428