### PR TITLE
wpewebkit: Fix license warnings for Yocto releases previous to kirkstone

### DIFF
--- a/recipes-browser/wpewebkit/wpewebkit.inc
+++ b/recipes-browser/wpewebkit/wpewebkit.inc
@@ -3,7 +3,7 @@ SUMMARY = "WPE WebKit port pairs the WebKit engine with OpenGL-ES (OpenGL for Em
            It is designed with hardware acceleration in mind, relying on EGL, and OpenGL ES."
 HOMEPAGE = "https://trac.webkit.org/wiki/WPE"
 BUGTRACKER = "https://bugs.webkit.org/"
-LICENSE = "BSD-2-Clause & LGPL-2.0-or-later"
+LICENSE = "BSD-2-Clause & ${@bb.utils.contains_any('LAYERSERIES_CORENAMES', 'dunfell gatesgarth hardknott honister', 'LGPL-2.0', 'LGPL-2.0-or-later', d)}"
 LIC_FILES_CHKSUM = "file://Source/WebCore/LICENSE-LGPL-2.1;md5=a778a33ef338abbaf8b8a7c36b6eec80 "
 
 DEPENDS = " \


### PR DESCRIPTION
This commit fixes this warning for the compatible releases to this
branch previous to kirkstone:

```
  WARNING: wpewebkit-2.36.3-r0 do_populate_lic: wpewebkit: No generic license file exists for: LGPL-2.0-or-later in any provider
  WARNING: do_rootfs: The license listed LGPL-2.0-or-later was not in the licenses collected for recipe wpewebkit
```

The LGPL-2.0-or-later license was added for Poky(kirkstone) in:

```
commit 2456f523cfbbae0e509797a0aefa9733f2cb13e3
Author: Meh Mbeh Ida Delphine <idadelm@gmail.com>
Date:   Thu Oct 15 21:45:39 2020 +0100

    licenses: Update license file to match current SPDX names
```

Unreviewed change