### PR TITLE
libjxl needs pkg-config to find libhwy (highway)

### DIFF
--- a/recipes-graphics/libjxl/libjxl.inc
+++ b/recipes-graphics/libjxl/libjxl.inc
@@ -37,7 +37,7 @@ EXTRA_OECMAKE = " -DBUILD_TESTING=OFF \
     -DJPEGXL_FORCE_SYSTEM_GTEST=ON \
     -DJPEGXL_FORCE_SYSTEM_HWY=ON"
 
-inherit cmake
+inherit cmake pkgconfig
 
 CXXFLAGS:append:arm = " -mfp16-format=ieee"
 


### PR DESCRIPTION
The CMake build system of libjxl relies on `pkg-config` to find the system `libhwl`. Inherit the `pkgconfig` class on the recipe.

This fixes the following build error:
```

| DEBUG: Executing shell function do_configure
| -- The C compiler identification is GNU 11.3.0
| -- The CXX compiler identification is GNU 11.3.0
| -- Detecting C compiler ABI info
| -- Detecting C compiler ABI info - done
| -- Check for working C compiler: /home/clopez/yocto/build-rpi3/tmp/work/cortexa7t2hf-neon-vfpv4-poky-linux-gnueabi/libjxl/0.6.1-r0/recipe-sysroot-native/usr/bin/arm-poky-linux-gnueabi/arm-poky-linux-gnueabi-gcc - skipped
| -- Detecting C compile features
| -- Detecting C compile features - done
| -- Detecting CXX compiler ABI info
| -- Detecting CXX compiler ABI info - done
| -- Check for working CXX compiler: /home/clopez/yocto/build-rpi3/tmp/work/cortexa7t2hf-neon-vfpv4-poky-linux-gnueabi/libjxl/0.6.1-r0/recipe-sysroot-native/usr/bin/arm-poky-linux-gnueabi/arm-poky-linux-gnueabi-g++ - skipped
| -- Detecting CXX compile features
| -- Detecting CXX compile features - done
| -- Performing Test JPEGXL_EMSCRIPTEN
| -- Performing Test JPEGXL_EMSCRIPTEN - Failed
| -- CMAKE_SYSTEM_PROCESSOR is arm
| -- Performing Test CXX_FUZZERS_SUPPORTED
| -- Performing Test CXX_FUZZERS_SUPPORTED - Failed
| -- Performing Test CXX_CONSTRUCTOR_ALIASES_SUPPORTED
| -- Performing Test CXX_CONSTRUCTOR_ALIASES_SUPPORTED - Failed
| -- Could NOT find PkgConfig (missing: PKG_CONFIG_EXECUTABLE)
| -- Compiled IDs C:GNU, C++:GNU
| -- Looking for pthread.h
| -- Looking for pthread.h - found
| -- Performing Test CMAKE_HAVE_LIBC_PTHREAD
| -- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Success
| -- Found Threads: TRUE
| CMake Error at third_party/CMakeLists.txt:93 (message):
|   Highway library (hwy) not found.  Install libhwy-dev or download it to
|   third_party/highway from https://github.com/google/highway .  Highway is
|   required to build JPEG XL.  You can run
|   /home/clopez/yocto/build-rpi3/tmp/work/cortexa7t2hf-neon-vfpv4-poky-linux-gnueabi/libjxl/0.6.1-r0/git/deps.sh
|   to download this dependency.
| 
| 
| -- Configuring incomplete, errors occurred!

```

The error is: ` -- Could NOT find PkgConfig (missing: PKG_CONFIG_EXECUTABLE)`