### PR TITLE
wpewebkit,webkitgtk: Bump up version to 2.36.4

### DIFF
--- a/recipes-browser/webkitgtk/webkitgtk_2.36.4.bb
+++ b/recipes-browser/webkitgtk/webkitgtk_2.36.4.bb
@@ -16,7 +16,7 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 SRC_URI = " \
     https://www.webkitgtk.org/releases/webkitgtk-${PV}.tar.xz;name=tarball \
 "
-SRC_URI[tarball.sha256sum] = "732fcf8c4ec644b8ed28b46ebbd7c1ebab9d9e0afea9bdf5e5d12786afc478d1"
+SRC_URI[tarball.sha256sum] = "b6bebe1f85a479d968c19e44a4704622ef8cef61636ad1b2406b77d16ae2e2a8"
 
 RRECOMMENDS:${PN} = "${PN}-bin \
                      ca-certificates \

--- a/recipes-browser/wpewebkit/wpewebkit_2.36.4.bb
+++ b/recipes-browser/wpewebkit/wpewebkit_2.36.4.bb
@@ -7,7 +7,7 @@ SRC_URI = "https://wpewebkit.org/releases/${BPN}-${PV}.tar.xz;name=tarball \
            file://0001-Fix-include-path-gstreamer-on-cross-toolchain.patch \
            "
 
-SRC_URI[tarball.sha256sum] = "66275debca7497daff3a7826734cd56262a807adb76c5dccdf257c89968c2fc8"
+SRC_URI[tarball.sha256sum] = "307a3bedf5d4299a861f773f631c39a44c3e6276c3af37f7cbefaed2c8d7c021"
 
 DEPENDS += " libwpe"
 RCONFLICTS:${PN} = "libwpe (< 1.10) wpebackend-fdo (< 1.10)"


### PR DESCRIPTION
* Fix the new ATSPI accessibility implementation to add the missing
  Collection interface for the loaded document.
* Fix the MediaSession implementation to make the MPRIS object names more
  sandbox friendly, which plays better with Flatpak and WebKit’s own
  Bubblwrap-based sandboxing.
* Fix leaked Web Processes in some particular situations.
* Fix the build with media capture support enabled.
* Fix cross-compilation when targeting 64-bit ARM.
* Fix several crashes and rendering issues.