### PR TITLE
wpewebkit,webkitgtk: Bump up version to 2.36.6

### DIFF
--- a/recipes-browser/webkitgtk/webkitgtk_2.36.6.bb
+++ b/recipes-browser/webkitgtk/webkitgtk_2.36.6.bb
@@ -16,7 +16,7 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 SRC_URI = " \
     https://www.webkitgtk.org/releases/webkitgtk-${PV}.tar.xz;name=tarball \
 "
-SRC_URI[tarball.sha256sum] = "b6bebe1f85a479d968c19e44a4704622ef8cef61636ad1b2406b77d16ae2e2a8"
+SRC_URI[tarball.sha256sum] = "1193bc821946336776f0dfa5e0dca5651f1e57157eda12da4721d2441f24a61a"
 
 RRECOMMENDS:${PN} = "${PN}-bin \
                      ca-certificates \

--- a/recipes-browser/wpewebkit/wpewebkit_2.36.6.bb
+++ b/recipes-browser/wpewebkit/wpewebkit_2.36.6.bb
@@ -7,7 +7,7 @@ SRC_URI = "https://wpewebkit.org/releases/${BPN}-${PV}.tar.xz;name=tarball \
            file://0001-Fix-include-path-gstreamer-on-cross-toolchain.patch \
            "
 
-SRC_URI[tarball.sha256sum] = "307a3bedf5d4299a861f773f631c39a44c3e6276c3af37f7cbefaed2c8d7c021"
+SRC_URI[tarball.sha256sum] = "e98a4eae2464ffaf4e5b53be08b9ae6386db511015c8002918b824d29f05d58f"
 
 DEPENDS += " libwpe"
 RCONFLICTS:${PN} = "libwpe (< 1.10) wpebackend-fdo (< 1.10)"


### PR DESCRIPTION
From 2.36.5:

* Add support for PAC proxy in the WebDriver implementation.
* Fix video playback when loaded through custom URIs, this fixes
  video playback in the Yelp documentation browser.
* Fix WebKitWebView::context-menu when using GTK4.
* Fix LTO builds with GCC.
* Fix several crashes and rendering issues.

From 2.35.6:

* Fix handling of touchpad scrolling on GTK4 builds.
* Fix WebKitGTK not allowing to be used from non-main threads.
* Fix several crashes and rendering issues.