### PR TITLE
Fix dependencies from cog and other recipes with libsoup/libsoup-2.4

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -30,7 +30,7 @@
     # setup-environment targetname machine distro bblayers presets
     # SOURCE: raspberrypi3-mesa-wpe-2.36 raspberrypi3-mesa poky layers.python2.raspberrypi.qt5.webkit conf_v3.wpe-2_36
     # MANIFEST: .gitlab-ci/manifest/manifest-kirkstone.xml
-    BITBAKE_TARGET: wpewebkit
+    BITBAKE_TARGET: cog
   script:
     - bitbake $BITBAKE_TARGET
     - rm -rf tmp

--- a/.gitlab-ci/template/presets/wpe-2_36.conf
+++ b/.gitlab-ci/template/presets/wpe-2_36.conf
@@ -1,6 +1,6 @@
 PREFERRED_PROVIDER_virtual/wpebackend = "wpebackend-fdo"
 PREFERRED_PROVIDER_virtual/libwpe = "libwpe"
-PREFERRED_VERSION_cog = "0.12.%"
+PREFERRED_VERSION_cog = "0.14.%"
 PREFERRED_VERSION_wpewebkit = "2.36.%"
 PREFERRED_VERSION_wpebackend-fdo = "1.12.%"
 PREFERRED_VERSION_wpebackend-rdk = "1.20200213"

--- a/recipes-browser/cog/cog.inc
+++ b/recipes-browser/cog/cog.inc
@@ -17,7 +17,8 @@ SRC_URI = "https://wpewebkit.org/releases/${P}.tar.xz"
 DEPENDS = " \
             ${@bb.utils.contains('PACKAGECONFIG', 'webkitgtk', 'webkitgtk', 'wpewebkit', d)} \
             ${@bb.utils.contains('PACKAGECONFIG', 'fdo', 'wayland', '', d)} \
-            libsoup-2.4 glib-2.0 wayland-native wayland-protocols \
+            ${@bb.utils.contains_any('LAYERSERIES_CORENAMES', 'dunfell gatesgarth hardknott honister', 'libsoup-2.4', 'libsoup', d)} \
+            glib-2.0 wayland-native wayland-protocols \
             "
 
 DEPENDS:append:class-target = " \

--- a/recipes-browser/cog/cog/0001-cmake-Fix-CMake-v3.16-cannot-create-ALIAS-target-Wpe.patch
+++ b/recipes-browser/cog/cog/0001-cmake-Fix-CMake-v3.16-cannot-create-ALIAS-target-Wpe.patch
@@ -1,0 +1,43 @@
+From eddc6a58f84d4b89599101ff374290fba7e7645c Mon Sep 17 00:00:00 2001
+From: Pablo Saavedra <psaavedra@igalia.com>
+Date: Tue, 6 Sep 2022 11:24:07 +0200
+Subject: [PATCH] cmake: Fix CMake (v3.16) cannot create ALIAS target
+ "Wpe::FDO" error
+
+... because target "PkgConfig::WpeFDO" is imported but not globally
+visible in cmake/FindWpeFDO.cmake.
+
+Notice that this issue is not reproducible in CMake v3.22.
+
+CMake doc [1][2] says:
+
+"The scope of the definition of an IMPORTED target is the directory
+where it was defined. It may be accessed and used from
+subdirectories, but not from parent directories or sibling directories.
+The scope is similar to the scope of a cmake variable.
+
+It is also possible to define a GLOBAL IMPORTED target which is
+accessible globally in the buildsystem."
+
+[1] 3.16: https://cmake.org/cmake/help/v3.16/manual/cmake-buildsystem.7.html#imported-targets
+[2] latest: https://cmake.org/cmake/help/latest/manual/cmake-buildsystem.7.html#imported-targets
+---
+ cmake/FindWpeFDO.cmake | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+Upstream-Status: Submitted [https://github.com/Igalia/cog/pull/487]
+
+diff --git a/cmake/FindWpeFDO.cmake b/cmake/FindWpeFDO.cmake
+index 3a45757..b40a32e 100644
+--- a/cmake/FindWpeFDO.cmake
++++ b/cmake/FindWpeFDO.cmake
+@@ -1,5 +1,5 @@
+ find_package (PkgConfig REQUIRED QUIET)
+-pkg_check_modules(WpeFDO QUIET wpebackend-fdo-1.0>=1.8.0 IMPORTED_TARGET)
++pkg_check_modules(WpeFDO QUIET wpebackend-fdo-1.0>=1.8.0 GLOBAL IMPORTED_TARGET)
+ 
+ if (TARGET PkgConfig::WpeFDO)
+   add_library(Wpe::FDO ALIAS PkgConfig::WpeFDO)
+-- 
+2.34.1
+

--- a/recipes-browser/cog/cog_0.12.4.bb
+++ b/recipes-browser/cog/cog_0.12.4.bb
@@ -3,5 +3,5 @@ require cog.inc
 SRC_URI:append = " file://0001-Fix-missing-xkbcommon.h-include.patch"
 SRC_URI[sha256sum] = "9983c621c8e14fca3792ff566cb6b86d6a1f17446eb4c083af4a5a749112982f"
 
-RDEPENDS:${PN} += "wpewebkit (>= 2.34)"
+RDEPENDS:${PN} += "wpewebkit (>= 2.34) wpewebkit (< 2.36)"
 

--- a/recipes-browser/cog/cog_0.12.4.bb
+++ b/recipes-browser/cog/cog_0.12.4.bb
@@ -5,3 +5,6 @@ SRC_URI[sha256sum] = "9983c621c8e14fca3792ff566cb6b86d6a1f17446eb4c083af4a5a7491
 
 RDEPENDS:${PN} += "wpewebkit (>= 2.34) wpewebkit (< 2.36)"
 
+# Releases <0.14 depend on libsoup 2.4
+DEPENDS += "libsoup-2.4"
+

--- a/recipes-browser/cog/cog_0.14.0.bb
+++ b/recipes-browser/cog/cog_0.14.0.bb
@@ -8,3 +8,9 @@ SRCREV:class-devupstream = "343563b0866bc1802acbbdbb5f163bf9eba5c0ff"
 
 RDEPENDS:${PN} += "wpewebkit (>= 2.36)"
 
+PACKAGECONFIG[soup2] = "-DUSE_SOUP2=ON,-DUSE_SOUP2=OFF,libsoup-2.4"
+
+# libsoup-3 is not available before Poky kirkstone.
+# http://git.yoctoproject.org/cgit/cgit.cgi/poky/commit/meta/recipes-support/libsoup/libsoup_3.0.1.bb?id=de296e2b2be876ca5cf2af309b710111e2b2581e
+PACKAGECONFIG:append = " ${@bb.utils.contains_any('LAYERSERIES_CORENAMES', 'dunfell gatesgarth hardknott honister', 'soup2', '', d)}"
+

--- a/recipes-browser/cog/cog_0.14.0.bb
+++ b/recipes-browser/cog/cog_0.14.0.bb
@@ -1,6 +1,7 @@
 require cog.inc
 require conf/include/devupstream.inc
 
+SRC_URI:append = " file://0001-cmake-Fix-CMake-v3.16-cannot-create-ALIAS-target-Wpe.patch"
 SRC_URI[sha256sum] = "e23936f1ce350ea5ea6fa0709b63d34776b05709388aed9c6cf3fdc41299de9f"
 
 SRC_URI:class-devupstream = "git://github.com/Igalia/cog.git;protocol=https;branch=cog-0.14"

--- a/recipes-browser/webkitgtk/webkitgtk_2.36.7.bb
+++ b/recipes-browser/webkitgtk/webkitgtk_2.36.7.bb
@@ -10,7 +10,9 @@ DEPENDS = "zlib libsoup-2.4 curl libxml2 cairo libxslt libidn \
            gtk+3 gstreamer1.0 gstreamer1.0-plugins-base flex-native icu \
            gperf-native perl-native ruby-native ccache-native ninja-native \
            libwebp harfbuzz glib-2.0 gettext-native glib-2.0-native \
-           sqlite3 libgcrypt"
+           sqlite3 libgcrypt \
+           ${@bb.utils.contains_any('LAYERSERIES_CORENAMES', 'dunfell gatesgarth hardknott honister', 'libsoup-2.4', 'libsoup', d)} \
+"
 
 FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 SRC_URI = " \
@@ -58,6 +60,7 @@ PACKAGECONFIG[libnotify] = "-DUSE_LIBNOTIFY=ON,-DUSE_LIBNOTIFY=OFF,libnotify"
 PACKAGECONFIG[libsecret] = "-DUSE_LIBSECRET=ON,-DUSE_LIBSECRET=OFF,libsecret"
 PACKAGECONFIG[opengl] = "-DENABLE_OPENGL=ON,-DENABLE_OPENGL=OFF,virtual/libgl"
 PACKAGECONFIG[openjpeg] = "-DUSE_OPENJPEG=ON,-DUSE_OPENJPEG=OFF,openjpeg"
+PACKAGECONFIG[soup2] = "-DUSE_SOUP2=ON,-DUSE_SOUP2=OFF,libsoup-2.4"
 PACKAGECONFIG[systemd] = "-DUSE_SYSTEMD=ON,-DUSE_SYSTEMD=OFF,systemd"
 PACKAGECONFIG[journald] = "-DENABLE_JOURNALD_LOG=ON,-DENABLE_JOURNALD_LOG=OFF,"
 PACKAGECONFIG[video] = "-DENABLE_VIDEO=ON,-DENABLE_VIDEO=OFF,gstreamer1.0 gstreamer1.0-plugins-base gstreamer1.0-plugins-good gstreamer1.0-plugins-bad"
@@ -74,9 +77,12 @@ EXTRA_OECMAKE = " \
                  -DENABLE_INTROSPECTION=OFF \
                  -DENABLE_GTKDOC=OFF \
                  -DENABLE_MINIBROWSER=ON \
-                 -DUSE_SOUP2=ON \
                  -G Ninja \
                 "
+
+# libsoup-3 is not available before Poky kirkstone.
+# http://git.yoctoproject.org/cgit/cgit.cgi/poky/commit/meta/recipes-support/libsoup/libsoup_3.0.1.bb?id=de296e2b2be876ca5cf2af309b710111e2b2581e
+PACKAGECONFIG:append = " ${@bb.utils.contains_any('LAYERSERIES_CORENAMES', 'dunfell gatesgarth hardknott honister', 'soup2', '', d)}"
 
 # Javascript JIT is not supported on ppc/arm < v6/RISCV/mips64
 PACKAGECONFIG:remove:powerpc = "jit"

--- a/recipes-browser/webkitgtk/webkitgtk_2.36.7.bb
+++ b/recipes-browser/webkitgtk/webkitgtk_2.36.7.bb
@@ -112,12 +112,12 @@ ARM_INSTRUCTION_SET:armv7ve = "thumb"
 
 # Install MiniBrowser in PATH
 do_install:append() {
-    if test -f ${D}${libexecdir}/webkit2gtk-4.0/MiniBrowser; then
+    if test -f ${D}${libexecdir}/webkit2gtk-4.1/MiniBrowser; then
         mkdir -p ${D}${bindir}
-        mv ${D}${libexecdir}/webkit2gtk-4.0/MiniBrowser ${D}${bindir}
+        mv ${D}${libexecdir}/webkit2gtk-4.1/MiniBrowser ${D}${bindir}
     fi
 }
 
-FILES:${PN} += "${libdir}/webkit2gtk-4.0/injected-bundle/libwebkit2gtkinjectedbundle.so"
-FILES:${PN}-dbg += "${libdir}/webkit2gtk-4.0/injected-bundle/.debug/libwebkit2gtkinjectedbundle.so"
-FILES:${PN}-dbg += "${libdir}/webkitgtk/webkit2gtk-4.0/.debug/*"
+FILES:${PN} += "${libdir}/webkit2gtk-4.1/injected-bundle/libwebkit2gtkinjectedbundle.so"
+FILES:${PN}-dbg += "${libdir}/webkit2gtk-4.1/injected-bundle/.debug/libwebkit2gtkinjectedbundle.so"
+FILES:${PN}-dbg += "${libdir}/webkitgtk/webkit2gtk-4.1/.debug/*"

--- a/recipes-browser/wpewebkit/wpewebkit.inc
+++ b/recipes-browser/wpewebkit/wpewebkit.inc
@@ -7,9 +7,10 @@ LICENSE = "BSD-2-Clause & ${@bb.utils.contains_any('LAYERSERIES_CORENAMES', 'dun
 LIC_FILES_CHKSUM = "file://Source/WebCore/LICENSE-LGPL-2.1;md5=a778a33ef338abbaf8b8a7c36b6eec80 "
 
 DEPENDS = " \
+    ${@bb.utils.contains_any('LAYERSERIES_CORENAMES', 'dunfell gatesgarth hardknott honister', 'libsoup-2.4', 'libsoup', d)} \
     bison-native gperf-native harfbuzz-native libxml2-native ccache-native ninja-native ruby-native cairo \
     fontconfig freetype glib-2.0 harfbuzz icu jpeg pcre sqlite3 zlib libpng \
-    libsoup-2.4 libwebp libxml2 libxslt virtual/egl virtual/libgles2 libepoxy libgcrypt \
+    libwebp libxml2 libxslt virtual/egl virtual/libgles2 libepoxy libgcrypt \
 "
 
 inherit cmake pkgconfig perlnative python3native
@@ -59,22 +60,30 @@ PACKAGECONFIG ??= "jit dfg-jit mediasource video webaudio webcrypto woff2 gst_gl
                    remote-inspector openjpeg unified-builds service-worker \
                   "
 
+# libsoup-3 is not available before Poky kirkstone.
+# http://git.yoctoproject.org/cgit/cgit.cgi/poky/commit/meta/recipes-support/libsoup/libsoup_3.0.1.bb?id=de296e2b2be876ca5cf2af309b710111e2b2581e
+PACKAGECONFIG:append = " ${@bb.utils.contains_any('LAYERSERIES_CORENAMES', 'dunfell gatesgarth hardknott honister', 'soup2', '', d)}"
+
 PACKAGECONFIG[reduce-size] = "-DCMAKE_BUILD_TYPE=MinSizeRel,-DCMAKE_BUILD_TYPE=Release,,"
 # WPE features
 PACKAGECONFIG[accessibility] = "-DENABLE_ACCESSIBILITY=ON,-DENABLE_ACCESSIBILITY=OFF,atk at-spi2-atk"
 PACKAGECONFIG[bubblewrap] = "-DENABLE_BUBBLEWRAP_SANDBOX=ON,-DENABLE_BUBBLEWRAP_SANDBOX=OFF,bubblewrap xdg-dbus-proxy bubblewrap-native xdg-dbus-proxy-native libseccomp"
 PACKAGECONFIG[developer-mode] = "-DDEVELOPER_MODE=ON,-DDEVELOPER_MODE=OFF,wayland-native wayland-protocols wpebackend-fdo"
 PACKAGECONFIG[deviceorientation] = "-DENABLE_DEVICE_ORIENTATION=ON,-DENABLE_DEVICE_ORIENTATION=OFF,"
+PACKAGECONFIG[dfg-jit] = "-DENABLE_DFG_JIT=ON,-DENABLE_DFG_JIT=OFF,"
 PACKAGECONFIG[encryptedmedia] = "-DENABLE_ENCRYPTED_MEDIA=ON,-DENABLE_ENCRYPTED_MEDIA=OFF,libgcrypt"
 # libjxl: Needed from 2.36
 PACKAGECONFIG[experimental-features] = "-DENABLE_EXPERIMENTAL_FEATURES=ON,-DENABLE_EXPERIMENTAL_FEATURES=OFF,libavif libjxl"
 PACKAGECONFIG[gamepad] = "-DENABLE_GAMEPAD=ON,-DENABLE_GAMEPAD=OFF,"
 PACKAGECONFIG[geolocation] = "-DENABLE_GEOLOCATION=ON,-DENABLE_GEOLOCATION=OFF,geoclue"
 PACKAGECONFIG[gst_gl] = "-DUSE_GSTREAMER_GL=ON,-DUSE_GSTREAMER_GL=OFF,gstreamer1.0-plugins-base"
+PACKAGECONFIG[jit] = "-DENABLE_JIT=ON,-DENABLE_JIT=OFF,"
+PACKAGECONFIG[lcms] = "-DUSE_LCMS=ON,-DUSE_LCMS=OFF,"
 PACKAGECONFIG[minibrowser] = "-DENABLE_MINIBROWSER=ON,-DENABLE_MINIBROWSER=OFF,"
 PACKAGECONFIG[mediasource] = "-DENABLE_MEDIA_SOURCE=ON,-DENABLE_MEDIA_SOURCE=OFF,gstreamer1.0 gstreamer1.0-plugins-good"
 PACKAGECONFIG[mediastream] = "-DENABLE_MEDIA_STREAM=ON -DUSE_GSTREAMER_TRANSCODER=OFF,-DENABLE_MEDIA_STREAM=OFF,gstreamer1.0 gstreamer1.0-plugins-bad"
 PACKAGECONFIG[service-worker] = "-DENABLE_SERVICE_WORKER=ON,-DENABLE_SERVICE_WORKER=OFF,"
+PACKAGECONFIG[soup2] = "-DUSE_SOUP2=ON,-DUSE_SOUP2=OFF,libsoup-2.4"
 PACKAGECONFIG[video] = "-DENABLE_VIDEO=ON,-DENABLE_VIDEO=OFF,gstreamer1.0 gstreamer1.0-plugins-base"
 PACKAGECONFIG[webaudio] = "-DENABLE_WEB_AUDIO=ON,-DENABLE_WEB_AUDIO=OFF,gstreamer1.0 gstreamer1.0-plugins-base gstreamer1.0-plugins-good"
 PACKAGECONFIG[webcrypto] = "-DENABLE_WEB_CRYPTO=ON,-DENABLE_WEB_CRYPTO=OFF,libgcrypt libtasn1"
@@ -88,11 +97,6 @@ PACKAGECONFIG[unified-builds] = "-DENABLE_UNIFIED_BUILDS=ON,-DENABLE_UNIFIED_BUI
 PACKAGECONFIG[thunder] = "-DENABLE_THUNDER=ON,-DENABLE_THUNDER=OFF,virtual/open-cdm"
 PACKAGECONFIG[video-plane-display-dmabuf] = "-DUSE_WPE_VIDEO_PLANE_DISPLAY_DMABUF=ON,-DUSE_WPE_VIDEO_PLANE_DISPLAY_DMABUF=OFF,wpebackend-fdo"
 PACKAGECONFIG[webxr] = "-DENABLE_WEBXR=ON,-DENABLE_WEBXR=OFF,openxr"
-
-# Needed from 2.34
-PACKAGECONFIG[jit] = "-DENABLE_JIT=ON,-DENABLE_JIT=OFF,"
-PACKAGECONFIG[dfg-jit] = "-DENABLE_DFG_JIT=ON,-DENABLE_DFG_JIT=OFF,"
-PACKAGECONFIG[lcms] = "-DUSE_LCMS=ON,-DUSE_LCMS=OFF,"
 
 EXTRA_OECMAKE = " -DPORT=WPE -G Ninja"
 

--- a/recipes-browser/wpewebkit/wpewebkit_2.34.7.bb
+++ b/recipes-browser/wpewebkit/wpewebkit_2.34.7.bb
@@ -29,7 +29,3 @@ PACKAGECONFIG:remove:riscv32 = "gold"
 PACKAGECONFIG:remove:riscv64 = "gold"
 PACKAGECONFIG:remove:mipsarcho32 = "gold"
 
-# libsoup-3 will be available not before Poky kirkstone.
-# http://git.yoctoproject.org/cgit/cgit.cgi/poky/commit/meta/recipes-support/libsoup/libsoup_3.0.1.bb?id=de296e2b2be876ca5cf2af309b710111e2b2581e
-EXTRA_OECMAKE += "-DUSE_SOUP2=ON"
-

--- a/recipes-browser/wpewebkit/wpewebkit_2.36.7.bb
+++ b/recipes-browser/wpewebkit/wpewebkit_2.36.7.bb
@@ -23,7 +23,3 @@ SRCREV:class-devupstream = "b3f12a91b11b34b71aa4ec64c1806616b45bd877"
 PACKAGECONFIG[journald] = "-DENABLE_JOURNALD_LOG=ON,-DENABLE_JOURNALD_LOG=OFF,"
 PACKAGECONFIG:append = " ${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'journald', '' ,d)}"
 
-# libsoup-3 will be available not before Poky kirkstone.
-# http://git.yoctoproject.org/cgit/cgit.cgi/poky/commit/meta/recipes-support/libsoup/libsoup_3.0.1.bb?id=de296e2b2be876ca5cf2af309b710111e2b2581e
-EXTRA_OECMAKE += "-DUSE_SOUP2=ON"
-


### PR DESCRIPTION
* wpewebkit: Built with libsoup-2.4 or libsoup (version 3) depending on the LAYERSERIES_CORENAMES
* webkitgtk: Built with libsoup-2.4 or libsoup (version 3) depending on the LAYERSERIES_CORENAMES
* cog: Built with libsoup-2.4 or libsoup (version 3) depending on the LAYERSERIES_CORENAMES
* cog: Set runtime dependencies for cog 0.12 according with the Compatibility Components matrix on https://wpewebkit.org/release/schedule/
* ci: Update preset for WPE WebKit 2.36.X series
* ci: Build target set to cog. We want to be sure that cog and not only wpewebkit can be built with this layer/poky release convination.
