### PR TITLE
Change devupstream repo to the current location

### DIFF
--- a/recipes-browser/wpewebkit/wpewebkit_2.36.7.bb
+++ b/recipes-browser/wpewebkit/wpewebkit_2.36.7.bb
@@ -13,7 +13,7 @@ DEPENDS += " libwpe"
 RCONFLICTS:${PN} = "libwpe (< 1.10) wpebackend-fdo (< 1.10)"
 
 SRC_URI:class-devupstream = "\
-    git://git.webkit.org/WebKit.git;branch=master \
+    git://github.com/WebKit/WebKit.git;protocol=https;branch=main \
     file://0002-libyuv-gcc-issue.patch \
 "
 # WPE 2.36.X branch was forked from the main branch in this commit


### PR DESCRIPTION
This was changed a while ago, the old repo URL is frozen in time and we need newer sources for devupstream now.

Also remove the current SRCDEV commit pointing to an old branch, leaving it as comment because it's likely to be used in the future.

Thanks @aperezdc for the pointers.