### PR TITLE
Add 'lbse' packageconfig option WPE 2.38.

### DIFF
--- a/recipes-browser/wpewebkit/wpewebkit_2.38.0.bb
+++ b/recipes-browser/wpewebkit/wpewebkit_2.38.0.bb
@@ -30,3 +30,5 @@ PACKAGECONFIG[introspection] = "-DENABLE_INTROSPECTION=ON,-DENABLE_INTROSPECTION
 # causing cross-compiling build errors
 # PACKAGECONFIG:append = " ${@bb.utils.contains('DISTRO_FEATURES', 'api-documentation', 'documentation', '' ,d)} introspection"
 
+# Layer-Based SVG Engine
+PACKAGECONFIG[lbse] = "-DENABLE_LAYER_BASED_SVG_ENGINE=ON,-DENABLE_LAYER_BASED_SVG_ENGINE=OFF, "


### PR DESCRIPTION
This allows to build WPE with support for the new Layer-Based SVG engine.