### PR TITLE
wpewebkit: Add unifdef-native dependency for versions >2.38

### DIFF
--- a/recipes-browser/wpewebkit/wpewebkit_2.38.2.bb
+++ b/recipes-browser/wpewebkit/wpewebkit_2.38.2.bb
@@ -34,3 +34,6 @@ PACKAGECONFIG:append:class-devupstream = " webgl2"
 
 # Layer-Based SVG Engine
 PACKAGECONFIG[lbse] = "-DENABLE_LAYER_BASED_SVG_ENGINE=ON,-DENABLE_LAYER_BASED_SVG_ENGINE=OFF, "
+
+# unifdef-native: Needed since >2.38.
+DEPENDS:append:class-devupstream = " unifdef-native"


### PR DESCRIPTION
* wpewebkit: Add unifdef-native dependency for versions >2.38
* devupstream: Honors DEPENDS:class-devupstream

Fixes: #416