### PR TITLE
Install webkit test-fonts and test-dicts in /usr/share

### DIFF
--- a/recipes-devtools/dicts/test-dicts_git.bb
+++ b/recipes-devtools/dicts/test-dicts_git.bb
@@ -21,11 +21,9 @@ do_compile() {
 
 do_install() {
    cd ${S}
-   export DESTDIR=${D}
-   JHBUILD_PREFIX=""
-   make install
+   make DESTDIR="${D}/usr/share" install
 }
 
 FILES:${PN} = " \
-/webkitgtk-test-dicts/* \
+/usr/share/webkitgtk-test-dicts/* \
 "

--- a/recipes-devtools/fonts/webkit-test-fonts_git.bb
+++ b/recipes-devtools/fonts/webkit-test-fonts_git.bb
@@ -21,11 +21,9 @@ do_compile() {
 
 do_install() {
    cd ${S}
-   export DESTDIR=${D}
-   JHBUILD_PREFIX=""
-   make install
+   make DESTDIR="${D}/usr/share" install
 }
 
 FILES:${PN} = " \
-/webkitgtk-test-fonts/* \
+/usr/share/webkitgtk-test-fonts/* \
 "


### PR DESCRIPTION
The WebKit test tooling expects to find this helper files in `/usr/share` instead of in the rootfs. This is the path where those are installed also on the FlatPak SDK.

Reference: see `getFontsPath()` in source files `ActivateFontsGtk.cpp` and `ActivateFontsWPE.cpp` inside directory 'Tools' of WebKit as well as recipes for BuildStream `webkitgtk-test-dicts.bst` and `webkitgtk-test-fonts.bst` also inside on the 'Tools' directory of WebKit 