### PR TITLE
wpebackend-rdk: Update to last version and update packageconfig entries

### DIFF
--- a/recipes-browser/wpebackend-rdk/wpebackend-rdk.inc
+++ b/recipes-browser/wpebackend-rdk/wpebackend-rdk.inc
@@ -10,7 +10,7 @@ SRC_URI = "git://github.com/WebPlatformForEmbedded/WPEBackend-rdk.git;protocol=g
 PROVIDES += "virtual/wpebackend"
 RPROVIDES:${PN} += "virtual/wpebackend"
 
-DEPENDS = "libwpe glib-2.0 libinput"
+DEPENDS = "libwpe virtual/egl glib-2.0 libxkbcommon xkeyboard-config libinput libudev"
 
 inherit cmake pkgconfig
 
@@ -18,17 +18,17 @@ inherit cmake pkgconfig
 PACKAGECONFIG ?= "wayland"
 
 # device specific backends
-PACKAGECONFIG[intelce] = "-DUSE_BACKEND_INTEL_CE=ON -DUSE_KEY_INPUT_HANDLING_LINUX_INPUT=ON,,intelce-display"
-PACKAGECONFIG[nexus] = "-DUSE_BACKEND_BCM_NEXUS=ON -DUSE_KEY_INPUT_HANDLING_LINUX_INPUT=ON,,broadcom-refsw"
-PACKAGECONFIG[rpi] = "-DUSE_BACKEND_BCM_RPI=ON -DUSE_KEY_INPUT_HANDLING_LINUX_INPUT=ON,,userland"
-PACKAGECONFIG[stm] = "-DUSE_BACKEND_STM=ON -DUSE_KEY_INPUT_HANDLING_LINUX_INPUT=OFF,,libxkbcommon xkeyboard-config"
-PACKAGECONFIG[imx6] =  "-DUSE_BACKEND_VIV_IMX6_EGL=ON -DUSE_KEY_INPUT_HANDLING_LINUX_INPUT=ON,,imx-gpu-viv"
+PACKAGECONFIG[intelce] = "-DUSE_BACKEND_INTEL_CE=ON,,intelce-display"
+PACKAGECONFIG[nexus] = "-DUSE_BACKEND_BCM_NEXUS=ON,,broadcom-refsw"
+PACKAGECONFIG[rpi] = "-DUSE_BACKEND_BCM_RPI=ON,,userland"
+PACKAGECONFIG[stm] = "-DUSE_BACKEND_STM=ON,,"
+PACKAGECONFIG[imx6] = "-DUSE_BACKEND_VIV_IMX6_EGL=ON,,imx-gpu-viv"
 
 # Wayland selectors
-PACKAGECONFIG[wayland] = "-DUSE_BACKEND_WAYLAND_EGL=ON -DUSE_KEY_INPUT_HANDLING_LINUX_INPUT=OFF,,wayland libxkbcommon xkeyboard-config"
-PACKAGECONFIG[realtek] = "-DUSE_BACKEND_REALTEK=ON -DUSE_KEY_INPUT_HANDLING_LINUX_INPUT=OFF,,wayland libxkbcommon xkeyboard-config"
-PACKAGECONFIG[westeros] = "-DUSE_BACKEND_WESTEROS=ON -DUSE_BACKEND_BCM_RPI=OFF -DUSE_KEY_INPUT_HANDLING_LINUX_INPUT=OFF -DUSE_WESTEROS_SINK=ON,,wayland westeros libxkbcommon xkeyboard-config"
-PACKAGECONFIG[bcm-weston] = "-DUSE_BACKEND_BCM_NEXUS_WAYLAND=ON,-DUSE_BACKEND_BCM_NEXUS_WAYLAND=OFF,,"
+PACKAGECONFIG[wayland] = "-DUSE_BACKEND_WAYLAND_EGL=ON,,wayland"
+PACKAGECONFIG[realtek] = "-DUSE_BACKEND_REALTEK=ON,,wayland"
+PACKAGECONFIG[westeros] = "-DUSE_BACKEND_WESTEROS=ON,,wayland westeros"
+PACKAGECONFIG[bcm-weston] = "-DUSE_BACKEND_BCM_NEXUS_WAYLAND=ON,,,"
 PACKAGECONFIG[westeros-mesa] = "-DUSE_BACKEND_WESTEROS_MESA=ON,,"
 
 do_install() {

--- a/recipes-browser/wpebackend-rdk/wpebackend-rdk_1.20221201.bb
+++ b/recipes-browser/wpebackend-rdk/wpebackend-rdk_1.20221201.bb
@@ -2,8 +2,8 @@ require wpebackend-rdk.inc
 
 DEPENDS = "libwpe glib-2.0 libinput"
 
-PV = "1.20200213"
-SRCREV = "3ec8dfd1a1f1cede256fd5de0a63a8c6b6a31ffa"
+PV = "1.20221201"
+SRCREV = "f0475a271211efc501fc810304b5dc69a5e12bbb"
 
 SRC_URI = "git://github.com/WebPlatformForEmbedded/WPEBackend-rdk.git;protocol=https;branch=master"
 
@@ -14,6 +14,6 @@ BBCLASSEXTEND += "devupstream:target"
 PROVIDES:append:class-devupstream = " virtual/wpebackend"
 
 SRC_URI:class-devupstream = "git://github.com/WebPlatformForEmbedded/WPEBackend-rdk.git;protocol=https;branch=master"
-SRCREV:class-devupstream = "3ec8dfd1a1f1cede256fd5de0a63a8c6b6a31ffa"
+SRCREV:class-devupstream = "f0475a271211efc501fc810304b5dc69a5e12bbb"
 
 RPROVIDES:${PN}:append:class-devupstream = "virtual/wpebackend"


### PR DESCRIPTION
* Update recipe to the last version
* Move some dependencies related to input handling to be unconditional. The build will fail without them.
* Remove cmake options that not longer exist like `USE_KEY_INPUT_HANDLING_LINUX_INPUT`
* Simply the options for the backends: all of them are disabled by default, so we only have to enable the cmake option if selected.