### PR TITLE
Add a new image and distro definition for using on the WebKit CI for WPE perf bots

### DIFF
--- a/conf/distro/webkitdevci.conf
+++ b/conf/distro/webkitdevci.conf
@@ -1,0 +1,36 @@
+# Distro based on Poky
+require conf/distro/poky.conf
+
+DISTRO = "webkitdevci"
+DISTRO_NAME= "WebKit Dev@CI (Yocto Poky Based Distro)"
+
+# Expand inmediately (:=) this two variables as soon as they are assigned (now),
+# otherwise the (default) lazy expansion causes issues with BASEFILESISSUEINSTALL
+# at recipe 'base-files' due to 'metadata not deterministic' errors.
+# This two environment variables are automatically set by the script 'cross-toolchain-helper'
+# of WebKit. The purpose of them is to define into the image in the file /etc/os-release
+# the target pretty name and an unique version identifier of the image.
+# In case of building this recipe outside of the environment created by the script
+# 'cross-toolchain-helper' then this identifiers will default to the machine name
+# as defined in local.conf and the current date string.
+# This information is useful to detect when the image that is running on a board like a WPE
+# RPi performance bot doesn't match the version that should be running (as calculated from
+# the sources of the image definition of the WebKit checkout).
+# For more details about this see: https://bugs.webkit.org/show_bug.cgi?id=249031
+WEBKIT_CROSS_TARGET := "${@d.getVar('BB_ORIGENV').getVar('WEBKIT_CROSS_TARGET') or '${MACHINE}'}"
+WEBKIT_CROSS_VERSION := "${@d.getVar('BB_ORIGENV').getVar('WEBKIT_CROSS_VERSION') or '${DATE}'}"
+
+DISTRO_NAME:append = " [target ${WEBKIT_CROSS_TARGET}]"
+DISTRO_VERSION:append = "_${WEBKIT_CROSS_VERSION}"
+
+DISTROOVERRIDES:append = " poky:linuxstdbase"
+
+# Distro features
+DISTRO_FEATURES:append = " opengl egl pam systemd"
+DISTRO_FEATURES:remove = "ptest"
+DISTRO_FEATURES_NATIVESDK:append = " wayland"
+
+# Use systemd
+DISTRO_FEATURES_BACKFILL_CONSIDERED = "sysvinit"
+VIRTUAL-RUNTIME_init_manager = "systemd"
+VIRTUAL-RUNTIME_dev_manager = "systemd"

--- a/recipes-browser/images/webkit-dev-ci-tools.bb
+++ b/recipes-browser/images/webkit-dev-ci-tools.bb
@@ -1,0 +1,120 @@
+SUMMARY = "Image with all the required tools to build WPE (using the script build-webkit) \
+           and also run the tests (layout-tests, performance-tests, api-tests, etc). \
+           The SDK that gets build with 'bitbake ${IMAGENAME} -c populate_sdk' is valid \
+           for using in the host with the script build-webkit and the image itself has \
+           the tools to run the tests on the board. But the image doesn't contain \
+           webkit (wpe) itself. The purpose of this image is for using on the \
+           continous integration systems of webkit.org for WPE tests. \
+           For more info see the WebKit script named cross-toolchain-helper."
+
+LICENSE = "MIT"
+
+# Default values that can be overriden by the user are set before including
+# anything so they take precedence as default value.
+XZ_COMPRESSION_LEVEL ?= "-6"
+SDK_XZ_COMPRESSION_LEVEL ?= "-0"
+
+inherit core-image features_check
+
+# Add 'dbg-pkgs' to this list or to EXTRA_IMAGE_FEATURES in local.conf if
+# you want debug symbols installed on the image. It is not added by default
+# because it increases the image size quite a bit (from 4GB to 10GB unpacked)
+IMAGE_FEATURES += " \
+                    debug-tweaks \
+                    dev-pkgs \
+                    hwcodecs \
+                    package-management \
+                    splash \
+                    ssh-server-openssh \
+                    tools-debug \
+                    tools-profile \
+                    tools-sdk \
+                    tools-testapps \
+                    "
+REQUIRED_DISTRO_FEATURES = "opengl wayland"
+
+IMAGE_LINGUAS = "en-us es-es"
+GLIBC_GENERATE_LOCALES = "en_US.UTF-8 es_ES.UTF-8"
+
+IMAGE_INSTALL:append = " \
+    alsa-tools \
+    alsa-utils-aconnect \
+    alsa-utils-alsactl \
+    alsa-utils-alsaloop \
+    alsa-utils-alsamixer \
+    alsa-utils-alsatplg \
+    alsa-utils-amixer \
+    alsa-utils-aplay \
+    alsa-utils-midi \
+    alsa-utils-speakertest \
+    apache2 apache2-scripts \
+    bridge-utils \
+    curl\
+    dhcpcd \
+    e2fsprogs-badblocks \
+    e2fsprogs-e2fsck \
+    e2fsprogs-mke2fs \
+    e2fsprogs-resize2fs \
+    e2fsprogs-tune2fs \
+    gdb \
+    gdbserver \
+    htop \
+    libtasn1 \
+    lzo \
+    nano \
+    ntp \
+    packagegroup-core-full-cmdline \
+    parted \
+    perf \
+    pv \
+    smem \
+    systemd-analyze \
+    "
+
+SDK_NATIVE_TOOLS = " \
+    nativesdk-bison \
+    nativesdk-ca-certificates \
+    nativesdk-ccache \
+    nativesdk-cmake \
+    nativesdk-gi-docgen \
+    nativesdk-glib-2.0-codegen \
+    nativesdk-glib-2.0-utils \
+    nativesdk-gperf \
+    nativesdk-harfbuzz \
+    nativesdk-libxml2 \
+    nativesdk-libxml2-utils \
+    nativesdk-ninja \
+    nativesdk-perl \
+    nativesdk-perl-misc \
+    nativesdk-perl-module-findbin \
+    nativesdk-perl-modules \
+    nativesdk-python-is-python3 \
+    nativesdk-python3 \
+    nativesdk-python3-certifi \
+    nativesdk-ruby \
+    nativesdk-unifdef \
+    nativesdk-wayland-dev \
+    "
+
+TOOLCHAIN_HOST_TASK:append = "${SDK_NATIVE_TOOLS}"
+TOOLCHAIN_TARGET_TASK:append = " openjpeg-staticdev libjxl"
+TOOLCHAIN_TARGET_TASK:remove = "target-sdk-provides-dummy"
+
+IMAGE_INSTALL:append = " ${@bb.utils.contains('DISTRO_FEATURES', 'x11 wayland', 'xwayland weston-xwayland', '', d)}"
+IMAGE_INSTALL:append = " ${@bb.utils.contains('DISTRO_FEATURES', 'wayland', 'weston-init weston-examples waylandeglinfo', '', d)}"
+IMAGE_INSTALL:append = " ${PREFERRED_PROVIDER_virtual/wpebackend}"
+IMAGE_INSTALL:append = " packagegroup-wpewebkit-depends"
+
+# Allow dropbear/openssh to accept root logins if debug-tweaks or allow-root-login is enabled
+ROOTFS_POSTPROCESS_COMMAND += "ssh_internal_sftp; "
+
+#
+# Set a valid internal-sftp
+#
+ssh_internal_sftp () {
+        for config in sshd_config sshd_config_readonly; do
+                if [ -e ${IMAGE_ROOTFS}${sysconfdir}/ssh/$config ]; then
+                        sed -i 's/^[#[:space:]]*Subsystem sftp.*/Subsystem sftp internal-sftp/' ${IMAGE_ROOTFS}${sysconfdir}/ssh/$config
+                fi
+        done
+}

--- a/recipes-browser/packagegroups/packagegroup-wpewebkit-depends.bb
+++ b/recipes-browser/packagegroups/packagegroup-wpewebkit-depends.bb
@@ -62,9 +62,13 @@ RDEPENDS:packagegroup-wpewebkit-depends-python = "\
     gmp \
     ncurses \
     openssl \
+    python-is-python3 \
     readline \
     zip \
 "
+
+STRACE = "strace"
+STRACE:riscv32 = ""
 
 RDEPENDS:packagegroup-wpewebkit-depends-misc = "\
     gettext \
@@ -76,8 +80,6 @@ RDEPENDS:packagegroup-wpewebkit-depends-misc = "\
     usbutils \
     rpm \
     "
-STRACE = "strace"
-STRACE:riscv32 = ""
 
 RDEPENDS:packagegroup-wpewebkit-depends-core = "\
     at \
@@ -132,7 +134,7 @@ RDEPENDS:packagegroup-wpewebkit-depends-core = "\
     sqlite3 \
     zlib \
     libpng \
-    libsoup-2.4 \
+   ${@bb.utils.contains_any('LAYERSERIES_CORENAMES', 'dunfell gatesgarth hardknott honister', 'libsoup-2.4', 'libsoup', d)} \
     libwebp \
     libxml2 \
     libxslt \
@@ -142,7 +144,15 @@ RDEPENDS:packagegroup-wpewebkit-depends-core = "\
     xdg-dbus-proxy \
     ${@bb.utils.contains('BBFILE_COLLECTIONS', 'security', 'libseccomp', '', d)} \
     libicudata \
+    libwpe \
+    ${PREFERRED_PROVIDER_virtual/wpebackend} \
+    libgpg-error \
+    libgcrypt \
+    libepoxy \
+    wayland-protocols \
+    openjpeg \
 "
+
 RDEPENDS:packagegroup-wpewebkit-depends-core:append:libc-glibc = "\
     glibc \
     glibc-utils \
@@ -229,6 +239,7 @@ RDEPENDS:packagegroup-wpewebkit-depends-video = " \
     gstreamer1.0-plugins-bad-mpegtsdemux \
     gstreamer1.0-plugins-bad-smoothstreaming \
     gstreamer1.0-plugins-bad-videoparsersbad \
+    gstreamer1.0-libav \
 "
 
 RDEPENDS:packagegroup-wpewebkit-depends-extra = " \
@@ -258,25 +269,20 @@ RDEPENDS:packagegroup-wpewebkit-depends-tests = " \
     pulseaudio-misc \
     perl \
     perl-module-file-spec \
-    perl-module-cgi \
+    libcgi-perl \
+    libarchive-zip-perl \
     test-dicts \
     webkit-test-fonts \
     ruby \
     ruby-highline \
     ruby-json \
-    brotli \
-    libsoup-2.4 \
-    cairo \
-    fontconfig \
-    freetype \
-    harfbuzz \
-    icu \
-    woff2 \
-    libwpe \
-    wpebackend-fdo \
-    libgpg-error \
-    libgcrypt \
-    libepoxy \
-    wayland-protocols \
-    openjpeg \
+    python3-dev \
+    python3-pip \
+    python3-psutil \
+    python3-pygobject \
+    python3-twisted \
+    libc6-dev \
+    gcc \
+    g++ \
+    gcc-dev \
 "

--- a/recipes-devtools/python/python-is-python3.bb
+++ b/recipes-devtools/python/python-is-python3.bb
@@ -1,0 +1,16 @@
+DESCRIPTION = "Convenience package which ships a symlink to point the python interpreter to python3"
+LICENSE = "PSF-2.0"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/PSF-2.0;md5=76c1502273262a5ebefb50dfb20d7c4f"
+
+S = "${WORKDIR}"
+
+do_install() {
+   mkdir -p ${D}/${bindir}
+   ln -sf python3 ${D}/${bindir}/python
+}
+
+FILES:${PN} = "${bindir}/python"
+RDEPENDS:${PN} = "python3"
+RCONFLICTS:${PN} = "python"
+
+BBCLASSEXTEND = "native nativesdk"


### PR DESCRIPTION
* This adds a new image named `core-image-webkit-dev-ci-tools-tests` which will be used on the WebKit CI for building an image containing everything needed to build WebKit and run tests (perf-tests, layout-tests, etc). The image itself doesn't contain WebKit (WPE).

* It adds also a `python-is-python3` recipe that creates a symlink to provide the unversioned python interpreter as python3.

For more info see: https://bugs.webkit.org/show_bug.cgi?id=249604


Note: this patch is also on the WebKit PR at https://github.com/WebKit/WebKit/pull/7885 (file: [Tools/yocto/rpi/fix-nativesdk-image-defs.patch](https://github.com/WebKit/WebKit/blob/de647a4d3c36d2dd6923a8ac0ac653825c7790b5/Tools/yocto/rpi/fix-nativesdk-image-defs.patch))
The idea is to update that WebKit PR (or do a new PR if that one lands before this) with the reduced delta.