### PR TITLE
webkitgtk,wpewebkit: Version bump up to 2.38.3

### DIFF
--- a/recipes-browser/webkitgtk/webkitgtk_2.38.3.bb
+++ b/recipes-browser/webkitgtk/webkitgtk_2.38.3.bb
@@ -18,7 +18,7 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 SRC_URI = " \
     https://www.webkitgtk.org/releases/webkitgtk-${PV}.tar.xz;name=tarball \
 "
-SRC_URI[tarball.sha256sum] = "f3eb82899651f583b4d99cacd16af784a1a7710fce9e7b6807bd6ccde909fe3e"
+SRC_URI[tarball.sha256sum] = "41f001d1ed448c6936b394a9f20e4640eebf83a7f08262df28504f7410604a5a"
 
 RRECOMMENDS:${PN} = "${PN}-bin \
                      ca-certificates \

--- a/recipes-browser/wpewebkit/wpewebkit_2.38.3.bb
+++ b/recipes-browser/wpewebkit/wpewebkit_2.38.3.bb
@@ -7,7 +7,7 @@ SRC_URI = "https://wpewebkit.org/releases/${BPN}-${PV}.tar.xz;name=tarball \
            file://0001-FELightningNEON.cpp-fails-to-build-NEON-fast-path-se.patch \
           "
 
-SRC_URI[tarball.sha256sum] = "5ce5ac6d5cb6c13469f52d2ece34b302524ff59caf05ecf0f7c62e12c48df422"
+SRC_URI[tarball.sha256sum] = "1dd9075eec7253a1b0d038a73f92ddbb9174394e6a7527ec07b4464fa6290498"
 
 DEPENDS += " libwpe"
 RCONFLICTS:${PN} = "libwpe (< 1.12)"


### PR DESCRIPTION
* Fix runtime critical warnings from media player.
* Fix network process crash when fetching website data on ephemeral session.
* Fix the build with Ruby 3.2.
* Fix several crashes and rendering issues.