### PR TITLE
libvpx: add branch info to fetcher

### DIFF
--- a/recipes-multimedia/webm/libvpx_1.10.0.bb
+++ b/recipes-multimedia/webm/libvpx_1.10.0.bb
@@ -8,7 +8,7 @@ LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=d5b04755015be901744a78cc30d390d4"
 
 SRCREV = "b41ffb53f1000ab2227c1736d8c1355aa5081c40"
-SRC_URI += "git://chromium.googlesource.com/webm/libvpx;protocol=https \
+SRC_URI += "git://chromium.googlesource.com/webm/libvpx;protocol=https;branch=main \
             file://libvpx-configure-support-blank-prefix.patch \
            "
 


### PR DESCRIPTION
as this is mandatory for a while now and removes a warning from the build log