### PR TITLE
Add sparkle-cdm and flite to packagegroup-wpewebkit-depends-alternative

### DIFF
--- a/recipes-browser/packagegroups/packagegroup-wpewebkit-depends.bb
+++ b/recipes-browser/packagegroups/packagegroup-wpewebkit-depends.bb
@@ -198,17 +198,19 @@ RDEPENDS:packagegroup-wpewebkit-depends-runtime-add:append:libc-glibc = "\
 "
 
 RDEPENDS:packagegroup-wpewebkit-depends-alternative = " \
+    flite \
     geoclue \
-    libtasn1 \
-    woff2 \
     libavif \
-    libjxl \
-    libvpx \
     libevent \
+    libjxl \
     libopus \
+    libtasn1 \
+    libvpx \
+    openh264 \
     openjpeg \
     openxr \
-    openh264 \
+    sparkle-cdm \
+    woff2 \
 "
 
 RDEPENDS:packagegroup-wpewebkit-depends-video = " \


### PR DESCRIPTION
* sparkle-cdm recipe is provided by this layer (meta-webkit) and is needed to build WPE with ENABLE_THUNDER, which gets enabled by default when ENABLE_DEVELOPER_MODE is set.

* This allows to build WPE with some basic EME support at runtime, including clearkey layout tests coverage support.

This was suggested by @philn  at https://github.com/WebKit/WebKit/pull/7885#discussion_r1086482682