### PR TITLE
Add flite dependency only on 'langdale' and newer

### DIFF
--- a/recipes-browser/packagegroups/packagegroup-wpewebkit-depends.bb
+++ b/recipes-browser/packagegroups/packagegroup-wpewebkit-depends.bb
@@ -198,7 +198,7 @@ RDEPENDS:packagegroup-wpewebkit-depends-runtime-add:append:libc-glibc = "\
 "
 
 RDEPENDS:packagegroup-wpewebkit-depends-alternative = " \
-    flite \
+    ${@bb.utils.contains_any('LAYERSERIES_CORENAMES', 'dunfell gatesgarth hardknott honister', '', 'flite', d)} \
     geoclue \
     libavif \
     libevent \


### PR DESCRIPTION
On commit 5019d001d4a8fabba88800645bd7814f57764198 this dependency was added, but this is not available before langdale, so add it conditionally based on the Yocto release.

Thanks @psaavedra for the fix.