### PR TITLE
wpewebkit,webkitgtk: Bump up version to 2.38.4     

### DIFF
--- a/recipes-browser/libwpe/libwpe_1.14.1.bb
+++ b/recipes-browser/libwpe/libwpe_1.14.1.bb
@@ -2,7 +2,7 @@ require libwpe.inc
 require ${@bb.utils.contains_any("LAYERSERIES_CORENAMES", 'dunfell', 'libwpe-pkg-dunfell.inc', 'libwpe-pkg.inc', d)}
 require conf/include/devupstream.inc
 
-SRC_URI[sha256sum] = "c073305bbac5f4402cc1c8a4753bfa3d63a408901f86182051eaa5a75dd89c00"
+SRC_URI[sha256sum] = "b1d0cdcf0f8dbb494e65b0f7913e357106da9a0d57f4fbb7b9d1238a6dbe9ade"
 
 SRC_URI:class-devupstream = "git://github.com/WebPlatformForEmbedded/libwpe.git;protocol=https;branch=master"
 SRCREV:class-devupstream = "d8b7324fbdf1e25a34a0ac601fcc2264ba0fa704"

--- a/recipes-browser/webkitgtk/webkitgtk_2.38.4.bb
+++ b/recipes-browser/webkitgtk/webkitgtk_2.38.4.bb
@@ -18,7 +18,7 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 SRC_URI = " \
     https://www.webkitgtk.org/releases/webkitgtk-${PV}.tar.xz;name=tarball \
 "
-SRC_URI[tarball.sha256sum] = "41f001d1ed448c6936b394a9f20e4640eebf83a7f08262df28504f7410604a5a"
+SRC_URI[tarball.sha256sum] = "4f47ea29a2d4d5f15eef3dc9e2d6c6f067e8de863a3f64455e1ccf9693cc1d36"
 
 RRECOMMENDS:${PN} = "${PN}-bin \
                      ca-certificates \

--- a/recipes-browser/wpewebkit/wpewebkit_2.38.4.bb
+++ b/recipes-browser/wpewebkit/wpewebkit_2.38.4.bb
@@ -7,7 +7,7 @@ SRC_URI = "https://wpewebkit.org/releases/${BPN}-${PV}.tar.xz;name=tarball \
            file://0001-FELightningNEON.cpp-fails-to-build-NEON-fast-path-se.patch \
           "
 
-SRC_URI[tarball.sha256sum] = "1dd9075eec7253a1b0d038a73f92ddbb9174394e6a7527ec07b4464fa6290498"
+SRC_URI[tarball.sha256sum] = "8c1bc113ef151fb0be2640824d323bc755dc97295ab7a1bc05e7ec589937a07b"
 
 DEPENDS += " libwpe"
 RCONFLICTS:${PN} = "libwpe (< 1.12)"


### PR DESCRIPTION
... and also libwpe to 1.14.1
    
* Release notes:
  * https://webkitgtk.org/2023/02/02/webkitgtk2.38.4-released.html
  * https://wpewebkit.org/release/wpewebkit-2.38.4.html
  * https://wpewebkit.org/release/libwpe-1.14.1.html
