### PR TITLE
cog: Fix wrong var in use to add the selected platforms

### DIFF
--- a/recipes-browser/cog/cog-meson.inc
+++ b/recipes-browser/cog/cog-meson.inc
@@ -18,6 +18,6 @@ python __anonymous() {
     available_platforms = {'drm': 'drm', 'gtk4': 'gtk4', 'headless': 'headless', 'wl': 'wayland'}
     platforms = [platform for flag, platform in available_platforms.items() if flag in packageconfig]
     if platforms:
-        d.appendVar("EXTRA_OECONF", f" -Dplatforms={','.join(platforms)}")
+        d.appendVar("EXTRA_OEMESON", f" -Dplatforms={','.join(platforms)}")
 }
 


### PR DESCRIPTION
Also:

* graphene: disable neon support on arm 32bits (https://github.com/ebassi/graphene/issues/215). Upstream-status: [Reported](https://lists.openembedded.org/g/openembedded-devel/message/100996)