### PR TITLE
wpebackend-fdo: Bump to version 1.14.1

### DIFF
--- a/recipes-browser/wpebackend-fdo/wpebackend-fdo_1.14.0.bb
+++ b/recipes-browser/wpebackend-fdo/wpebackend-fdo_1.14.0.bb
@@ -1,4 +1,0 @@
-require wpebackend-fdo.inc
-
-SRC_URI[sha256sum] = "e75b0cb2c7145448416e8696013d8883f675c66c11ed750e06865efec5809155"
-

--- a/recipes-browser/wpebackend-fdo/wpebackend-fdo_1.14.1.bb
+++ b/recipes-browser/wpebackend-fdo/wpebackend-fdo_1.14.1.bb
@@ -1,0 +1,3 @@
+require wpebackend-fdo.inc
+
+SRC_URI[sha256sum] = "01938dd93c62b3a47b18dd13c70d50490a8b8a6caec23c8550a3dbdbcc6bbb50"

--- a/recipes-browser/wpebackend-fdo/wpebackend-fdo_devupstream.bb
+++ b/recipes-browser/wpebackend-fdo/wpebackend-fdo_devupstream.bb
@@ -4,5 +4,5 @@ require conf/include/devupstream.inc
 DEFAULT_PREFERENCE = "-1"
 
 SRC_URI = "git://github.com/Igalia/WPEBackend-fdo.git;protocol=https;branch=master"
-SRCREV = "cc6ea928a4d34e6e2199d7a4670d8b8b8261a3bb"
+SRCREV = "f2901c6ed7f720a578bfd5830d12426c979c0afa"
 S = "${WORKDIR}/git"


### PR DESCRIPTION
This version contains important correctness fixes. Release notes:

  https://wpewebkit.org/release/wpebackend-fdo-1.14.1.html