### PR TITLE
webkitdevci image: optimize list of packages and add quirk for RPi NFS boot.

### DIFF
--- a/conf/distro/webkitdevci.conf
+++ b/conf/distro/webkitdevci.conf
@@ -45,6 +45,8 @@ SYSTEMD_AUTO_ENABLE:pn-weston-init = "disable"
 PACKAGECONFIG:append:pn-weston-init = " no-idle-timeout"
 # Enable php plugins for apache (for tests)
 PACKAGECONFIG:append:pn-php = " apache2"
+# Disable mysql support as we don't need to build mysql/mariadb
+PACKAGECONFIG:remove:pn-php = "mysql"
 
 # Whitelist license from some deps.
 LICENSE_FLAGS_ACCEPTED:append = " commercial synaptics-killswitch"

--- a/recipes-browser/images/webkit-dev-ci-tools.bb
+++ b/recipes-browser/images/webkit-dev-ci-tools.bb
@@ -11,31 +11,35 @@ LICENSE = "MIT"
 
 # Default values that can be overriden by the user are set before including
 # anything so they take precedence as default value.
-XZ_COMPRESSION_LEVEL ?= "-6"
+# Note: xz -0 compresses better and faster than bzip2 with default values.
+XZ_COMPRESSION_LEVEL ?= "-0"
 SDK_XZ_COMPRESSION_LEVEL ?= "-0"
+
+# Use .xz instead of .bz2
+IMAGE_FSTYPES:append = " tar.xz wic.xz wic.bmap"
+IMAGE_FSTYPES:remove:rpi = "tar.bz2 wic.bz2 ext3"
 
 inherit core-image features_check
 
 # Add 'dbg-pkgs' to this list or to EXTRA_IMAGE_FEATURES in local.conf if
 # you want debug symbols installed on the image. It is not added by default
 # because it increases the image size quite a bit (from 4GB to 10GB unpacked)
-IMAGE_FEATURES += " \
+IMAGE_FEATURES:append = " \
                     debug-tweaks \
                     dev-pkgs \
                     hwcodecs \
                     package-management \
-                    splash \
                     ssh-server-openssh \
                     tools-debug \
                     tools-profile \
                     tools-sdk \
-                    tools-testapps \
                     "
 REQUIRED_DISTRO_FEATURES = "opengl wayland"
 
 IMAGE_LINGUAS = "en-us es-es"
 GLIBC_GENERATE_LOCALES = "en_US.UTF-8 es_ES.UTF-8"
 
+# Extra tools
 IMAGE_INSTALL:append = " \
     alsa-tools \
     alsa-utils-aconnect \
@@ -47,28 +51,44 @@ IMAGE_INSTALL:append = " \
     alsa-utils-aplay \
     alsa-utils-midi \
     alsa-utils-speakertest \
-    apache2 apache2-scripts \
+    apache2 \
+    apache2-scripts \
     bridge-utils \
-    curl\
+    cmake \
+    curl \
     dhcpcd \
     e2fsprogs-badblocks \
     e2fsprogs-e2fsck \
     e2fsprogs-mke2fs \
     e2fsprogs-resize2fs \
     e2fsprogs-tune2fs \
+    ethtool \
     gdb \
     gdbserver \
+    gi-docgen \
+    glib-2.0-codegen \
+    gperf \
     htop \
+    iperf3 \
+    ${@bb.utils.contains('PREFERRED_PROVIDER_virtual/egl', 'userland', '', 'kmscube', d)} \
+    libdrm-tests \
     libtasn1 \
     lzo \
+    mesa-demos \
+    meson \
     nano \
+    ninja \
     ntp \
     packagegroup-core-full-cmdline \
     parted \
     perf \
     pv \
+    screen \
     smem \
     systemd-analyze \
+    unifdef \
+    waylandeglinfo \
+    wayland-tools \
     "
 
 SDK_NATIVE_TOOLS = " \
@@ -105,16 +125,58 @@ IMAGE_INSTALL:append = " ${@bb.utils.contains('DISTRO_FEATURES', 'wayland', 'wes
 IMAGE_INSTALL:append = " ${PREFERRED_PROVIDER_virtual/wpebackend}"
 IMAGE_INSTALL:append = " packagegroup-wpewebkit-depends"
 
-# Allow dropbear/openssh to accept root logins if debug-tweaks or allow-root-login is enabled
-ROOTFS_POSTPROCESS_COMMAND += "ssh_internal_sftp; "
 
 #
 # Set a valid internal-sftp
 #
 ssh_internal_sftp () {
-        for config in sshd_config sshd_config_readonly; do
-                if [ -e ${IMAGE_ROOTFS}${sysconfdir}/ssh/$config ]; then
-                        sed -i 's/^[#[:space:]]*Subsystem sftp.*/Subsystem sftp internal-sftp/' ${IMAGE_ROOTFS}${sysconfdir}/ssh/$config
-                fi
-        done
+    for config in sshd_config sshd_config_readonly; do
+        if [ -e ${IMAGE_ROOTFS}${sysconfdir}/ssh/$config ]; then
+            sed -i 's/^[#[:space:]]*Subsystem sftp.*/Subsystem sftp internal-sftp/' ${IMAGE_ROOTFS}${sysconfdir}/ssh/$config
+        fi
+    done
 }
+
+#
+# Some machines like the RPi have /boot on a separated partition
+# and that causes that the rootfs tarball that is generated to miss
+# the files needed for booting via NFS. This function will copy the
+# IMAGE_BOOT_FILES on /boot in the rootfs to ensure that are also there.
+#
+copy_image_boot_files_to_slash_boot() {
+    # Functions for un/escape special shell glob characters "*?[{"
+    # Entries on IMAGE_BOOT_FILES can use glob patterns. See doc for it.
+    escape_shell_glob_chars() {
+        echo "$@" | sed -e 's/[*[?{]/\\&/g'
+    }
+    unescape_shell_glob_chars() {
+        echo "$@" | sed -e 's/\\\([*[?{]\)/\1/g'
+    }
+    # Copy the files taking into care the optional globbing and dest dirs
+    mkdir -p "${IMAGE_ROOTFS}/boot"
+    for BOOTFILE_ENTRY in $(escape_shell_glob_chars "${IMAGE_BOOT_FILES}"); do
+        if echo "${BOOTFILE_ENTRY}" | grep -q ';' ; then
+            GLOBSRCPATH="${DEPLOY_DIR_IMAGE}/$(echo ${BOOTFILE_ENTRY} | cut -d\; -f1)"
+            DSTPATH="$(echo ${BOOTFILE_ENTRY} | cut -d\; -f2)"
+            if echo "${DSTPATH}" | grep -q '/'; then
+                if echo "${DSTPATH}" | grep -qP '/$'; then
+                    DSTPATH="${IMAGE_ROOTFS}/boot/${DSTPATH}"
+                else
+                    DSTPATH="${IMAGE_ROOTFS}/boot/$(dirname ${DSTPATH})"
+                fi
+                mkdir -p "${DSTPATH}"
+            else
+                DSTPATH="${IMAGE_ROOTFS}/boot/${DSTPATH}"
+            fi
+        else
+            GLOBSRCPATH="${DEPLOY_DIR_IMAGE}/${BOOTFILE_ENTRY}"
+            DSTPATH="${IMAGE_ROOTFS}/boot"
+        fi
+        for SRCPATH in $(unescape_shell_glob_chars "${GLOBSRCPATH}"); do
+            cp "${SRCPATH}" "${DSTPATH}"
+        done
+    done
+}
+
+ROOTFS_POSTPROCESS_COMMAND += "ssh_internal_sftp; "
+ROOTFS_POSTPROCESS_COMMAND:append:rpi = "copy_image_boot_files_to_slash_boot; "


### PR DESCRIPTION
Some changes to improve the `webkitdevci` image:

* Optimize the list of packages that go into the image: remove big unneeded stuff like `mariadb/mysql` or `LTP` tests

* Remove also splash: better to see the logs of the init process.

* Add some packages needed to build cog and useful utilities.

* Switch default compression to `xz` (0 level): is faster than `bzip2` and compresses even better.

* Add `.tar.xz` as a default image format for this image (it will be the format used in the WebKit CI for the bots) and set `WIC` to use `xz` compression as well.

* Add a quirk for RPi that will copy into the `/boot` directory all the files needed to actually boot the RPi. This is very useful to create an image tarball (format `.tar.xz` for example) that is ready to boot via `NFS` instead of having to deal with individual boot files not packages inside the tarball.