### PR TITLE
wpewebkit: gst videoconvert/videoscale plugins were merged into one.

### DIFF
--- a/recipes-browser/packagegroups/packagegroup-wpewebkit-depends.bb
+++ b/recipes-browser/packagegroups/packagegroup-wpewebkit-depends.bb
@@ -227,8 +227,7 @@ RDEPENDS:packagegroup-wpewebkit-depends-video = " \
     gstreamer1.0-plugins-base-audioconvert \
     gstreamer1.0-plugins-base-audioresample \
     gstreamer1.0-plugins-base-gio \
-    gstreamer1.0-plugins-base-videoconvert \
-    gstreamer1.0-plugins-base-videoscale \
+    ${@bb.utils.contains_any('LAYERSERIES_CORENAMES', 'dunfell gatesgarth hardknott honister kirkstone langdale', 'gstreamer1.0-plugins-base-videoconvert gstreamer1.0-plugins-base-videoscale', 'gstreamer1.0-plugins-base-videoconvertscale', d)} \
     gstreamer1.0-plugins-base-volume \
     gstreamer1.0-plugins-base-typefindfunctions \
     gstreamer1.0-plugins-good-audiofx \

--- a/recipes-browser/wpewebkit/wpewebkit.inc
+++ b/recipes-browser/wpewebkit/wpewebkit.inc
@@ -140,6 +140,8 @@ ARM_INSTRUCTION_SET:armv7r = "thumb"
 ARM_INSTRUCTION_SET:armv7m = "thumb"
 ARM_INSTRUCTION_SET:armv7ve = "thumb"
 
+GSTVIDEOCONVERTSCALEPLUGIN = "${@bb.utils.contains_any('LAYERSERIES_CORENAMES', 'dunfell gatesgarth hardknott honister kirkstone langdale', 'gstreamer1.0-plugins-base-videoconvert gstreamer1.0-plugins-base-videoscale', 'gstreamer1.0-plugins-base-videoconvertscale', d)}"
+
 # Extra runtime depends
 RDEPENDS:${PN} += " \
     libgles2 \
@@ -153,9 +155,8 @@ RDEPENDS:${PN} += " \
                                                     gstreamer1.0-plugins-base-audioconvert \
                                                     gstreamer1.0-plugins-base-audioresample \
                                                     gstreamer1.0-plugins-base-gio \
-                                                    gstreamer1.0-plugins-base-videoconvert \
-                                                    gstreamer1.0-plugins-base-videoscale \
                                                     gstreamer1.0-plugins-base-volume \
+                                                    ${GSTVIDEOCONVERTSCALEPLUGIN} \
                                                     gstreamer1.0-plugins-base-typefindfunctions \
                                                     gstreamer1.0-plugins-good-audiofx \
                                                     gstreamer1.0-plugins-good-audioparsers \


### PR DESCRIPTION
A new plugin named gstreamer1.0-plugins-base-videoconvertscale contains the previous plugins videoconvert/videoscale merged.

Since Yocto >= Mickledore (4.2)
(  Yocto commit 4e07f56dced0b06d2cb60530e3989f656eede2cd or OE-Core rev: fb2d28e0315ece6180c87c7047587673024a09f7 )

Fixes: #459