### PR TITLE
loongarch64 JIT is not supported, remove it in wpewebkit.inc

### DIFF
--- a/recipes-browser/wpewebkit/wpewebkit.inc
+++ b/recipes-browser/wpewebkit/wpewebkit.inc
@@ -115,6 +115,7 @@ PACKAGECONFIG:remove:riscv32 = "jit"
 PACKAGECONFIG:remove:riscv64 = "jit"
 PACKAGECONFIG:remove:mipsarchn64 = "jit"
 PACKAGECONFIG:remove:mipsarchn32 = "jit"
+PACKAGECONFIG:remove:loongarch64 = "jit"
 
 # Javascript JIT is not supported on x86
 PACKAGECONFIG:remove:x86 = "jit"


### PR DESCRIPTION
Hi,
when i build wpewebkit and cog for loongarch architecture, it will report `ENABLE_JIT conflicts with ENABLE_C_LOOP.  You must disable one or the other.` error, so loongarch64 JIT is not supported, remove it in wpewebkit.inc.