### PR TITLE
cog: Bump-up version to 0.17.90

### DIFF
--- a/recipes-browser/cog/cog_0.17.90.bb
+++ b/recipes-browser/cog/cog_0.17.90.bb
@@ -4,10 +4,10 @@ require conf/include/devupstream.inc
 
 DEFAULT_PREFERENCE = "-1"
 
-SRC_URI[sha256sum] = "69e7d3b62c206210c3c436746d1241bfb99a1e789e6c4b7cb65dd9ae72459d42"
+SRC_URI[sha256sum] = "beb98996c48927e7283961877d45acb7f26ed71d78be9c4984fbff30ed0bedb7"
 
-SRC_URI:class-devupstream = "git://github.com/Igalia/cog.git;protocol=https;tag=0.17.1"
-SRCREV:class-devupstream = "0.17.1"
+SRC_URI:class-devupstream = "git://github.com/Igalia/cog.git;protocol=https;tag=0.17.90"
+SRCREV:class-devupstream = "0.17.90"
 
 # Required since https://github.com/Igalia/cog/commit/48dfac2ba637e223eeea1b289526d0f51e39ab88
 DEPENDS:append = " libxkbcommon"


### PR DESCRIPTION
* drm: Properly support input-less setups and situations in which the
  initialization of the XKB context may have failed.
* x11, wl: Make mouse scroll wheel behaviour snappier.
* launcher: Support passing the platform plug-in name and its parameters
  using environment variable
* webkit-utils: Check if the media engine will show the resource
    
      cog_handle_web_view_load_failed() checks if the error is
      WEBKIT_MEDIA_ERROR or WEBKIT_MEDIA_ERROR_WILL_HANDLE_LOAD and relies
      on WebKit in these cases.
    
      Similarly it does the same for the case of WPE API previous to 2.0
      but using WEBKIT_PLUGIN_ERROR and WEBKIT_PLUGIN_ERROR_WILL_HANDLE_LOAD



Upstream-Status: **Accepted** [[cog!569](https://github.com/Igalia/cog/pull/569/)]