### PR TITLE
wpewebkit: Remove patch to FELightningNEON

### DIFF
--- a/recipes-browser/wpewebkit/wpewebkit_2.40.1.bb
+++ b/recipes-browser/wpewebkit/wpewebkit_2.40.1.bb
@@ -4,7 +4,6 @@ require conf/include/devupstream.inc
 FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
 SRC_URI = "https://wpewebkit.org/releases/${BPN}-${PV}.tar.xz;name=tarball \
-           file://0001-FELightningNEON.cpp-fails-to-build-NEON-fast-path-se.patch \
           "
 
 SRC_URI[tarball.sha256sum] = "c6b25e168b70f2121305ed078d0790e0aa4b0c73fce44e32ed42d4e5dd137ccb"


### PR DESCRIPTION
Remove patch to FELightningNEON. This commits removes the patch to FELightningNEON from recipe wpewebkit version 2.40. In this version of wpewebkit the patch is not correctly applied and causes a build error.