### PR TITLE
highway: add patch to fix build issue with RPi4 and enable shared libs

### DIFF
--- a/recipes-extended/highway/files/pr_1589.patch
+++ b/recipes-extended/highway/files/pr_1589.patch
@@ -1,0 +1,54 @@
+From 22366edb5d6bd80b753c6eaeb4da76a4cb1b2d8c Mon Sep 17 00:00:00 2001
+From: Carlos Alberto Lopez Perez <clopez@igalia.com>
+Date: Sat, 22 Jul 2023 15:49:11 +0200
+Subject: [PATCH] HWY_NEON: Enable the crypto extension for GCC without setting
+ the full arch.
+
+This reverts commits 60241b99 and f8a6ea58.
+
+GCC understands (like Clang) appending an architecture extension on its own.
+This can be used to turn on and off particular architectural extensions
+without having to specify a particular architecture version or core.
+
+GCC supports this since at least 6.5. Check:
+https://gcc.gnu.org/onlinedocs/gcc-6.5.0/gcc/AArch64-Function-Attributes.html
+https://gcc.gnu.org/onlinedocs/gcc/AArch64-Function-Attributes.html
+
+This way we can enable the crypto architecture extension for HWY_NEON
+without overriding the default architecture of the compiler potentially
+disabling other architectural extensions.
+
+This fixes a build error that happens with the RPi4 and a Yocto-based toolchain
+that by default builds with `-march=armv8-a+crc` (the RPi4 has no crypto arch
+extension).
+So before this commit we ended building HWY_NEON with `-march=armv8-a+crypto`
+and that failed to build when it tried to inline code from other parts that by
+default is compiled with `-march=armv8-a+crc` (due to the toolchain in this
+example).
+
+The solution is to append the crypto extension, so in this example of the RPi4 we
+end compiling HWY_NEON with `-march=armv8-a+crc+crypto` allowing it to inline code
+from any other part that is built with `-march=armv8-a+crc`.
+See the documentation from GCC for the `Inlining rules` in the links from above.
+
+Issues related: #1570 and #1460.
+---
+ hwy/ops/set_macros-inl.h | 4 ----
+ 1 file changed, 4 deletions(-)
+
+diff --git a/hwy/ops/set_macros-inl.h b/hwy/ops/set_macros-inl.h
+index f64a6a5cf..806f95fbf 100644
+--- a/hwy/ops/set_macros-inl.h
++++ b/hwy/ops/set_macros-inl.h
+@@ -360,11 +360,7 @@
+ #if HWY_TARGET == HWY_NEON_WITHOUT_AES
+ // Do not define HWY_TARGET_STR (no pragma).
+ #else
+-#if HWY_COMPILER_GCC_ACTUAL
+-#define HWY_TARGET_STR "arch=armv8-a+crypto"
+-#else  // clang
+ #define HWY_TARGET_STR "+crypto"
+-#endif  // HWY_COMPILER_*
+ #endif  // HWY_TARGET == HWY_NEON_WITHOUT_AES
+ 
+ #endif  // HWY_ARCH_ARM_V7

--- a/recipes-extended/highway/highway.inc
+++ b/recipes-extended/highway/highway.inc
@@ -4,7 +4,8 @@ BUGTRACKER = "https://github.com/google/highway/issues"
 
 S = "${WORKDIR}/git"
 
-SRC_URI = "git://github.com/google/highway.git;protocol=https;branch=master"
+SRC_URI = "git://github.com/google/highway.git;protocol=https;branch=master \
+           file://pr_1589.patch"
 SRCREV = "46e365d6770f5d7a4240d8ac9d8e928a520478ea"
 
 LICENSE = "Apache-2.0"
@@ -13,7 +14,8 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=2b42edef8fa55315f34f2370b4715ca9"
 EXTRA_OECMAKE = " -DBUILD_TESTING=OFF \
     -DHWY_WARNINGS_ARE_ERRORS=OFF \
     -DHWY_ENABLE_EXAMPLES=OFF \
-    -DHWY_ENABLE_INSTALL=ON"
+    -DHWY_ENABLE_INSTALL=ON \
+    -DBUILD_SHARED_LIBS=ON "
 
 CXXFLAGS:append:arm = " -mfp16-format=ieee"
 


### PR DESCRIPTION
 * The patch was upstreamed at https://github.com/google/highway/pull/1589