### PR TITLE
wpebackend-rdk: update to last version and add new packageconfig options

### DIFF
--- a/recipes-browser/wpebackend-rdk/wpebackend-rdk.inc
+++ b/recipes-browser/wpebackend-rdk/wpebackend-rdk.inc
@@ -10,12 +10,12 @@ SRC_URI = "git://github.com/WebPlatformForEmbedded/WPEBackend-rdk.git;protocol=g
 PROVIDES += "virtual/wpebackend"
 RPROVIDES:${PN} += "virtual/wpebackend"
 
-DEPENDS:append = " libwpe virtual/egl glib-2.0 libxkbcommon xkeyboard-config libinput libudev"
+DEPENDS:append = " libwpe virtual/egl glib-2.0 libxkbcommon xkeyboard-config"
 
 inherit cmake pkgconfig
 
 
-PACKAGECONFIG ?= "wayland"
+PACKAGECONFIG ?= "wayland input-libinput input-udev"
 
 # device specific backends
 PACKAGECONFIG[intelce] = "-DUSE_BACKEND_INTEL_CE=ON,,intelce-display"
@@ -30,6 +30,11 @@ PACKAGECONFIG[realtek] = "-DUSE_BACKEND_REALTEK=ON,,wayland"
 PACKAGECONFIG[westeros] = "-DUSE_BACKEND_WESTEROS=ON,,wayland westeros"
 PACKAGECONFIG[bcm-weston] = "-DUSE_BACKEND_BCM_NEXUS_WAYLAND=ON,,,"
 PACKAGECONFIG[westeros-mesa] = "-DUSE_BACKEND_WESTEROS_MESA=ON,,"
+
+# Input backends
+PACKAGECONFIG[input-libinput] = "-DUSE_INPUT_LIBINPUT=ON,-DUSE_INPUT_LIBINPUT=OFF,libinput"
+PACKAGECONFIG[input-udev] = "-DUSE_INPUT_UDEV=ON,-DUSE_INPUT_UDEV=OFF,udev"
+PACKAGECONFIG[input-wayland] = "-DUSE_INPUT_WAYLAND=ON,-DUSE_INPUT_WAYLAND=OFF,wayland"
 
 do_install() {
 	install -d ${D}${libdir}

--- a/recipes-browser/wpebackend-rdk/wpebackend-rdk_1.20230523.bb
+++ b/recipes-browser/wpebackend-rdk/wpebackend-rdk_1.20230523.bb
@@ -3,7 +3,7 @@ require wpebackend-rdk.inc
 DEPENDS = "libwpe glib-2.0 libinput"
 
 PV = "1.20221201"
-SRCREV = "f0475a271211efc501fc810304b5dc69a5e12bbb"
+SRCREV = "108e4ab0da043421202e3ef64e0a38d1db8b82ee"
 
 SRC_URI = "git://github.com/WebPlatformForEmbedded/WPEBackend-rdk.git;protocol=https;branch=master"
 
@@ -14,6 +14,6 @@ BBCLASSEXTEND += "devupstream:target"
 PROVIDES:append:class-devupstream = " virtual/wpebackend"
 
 SRC_URI:class-devupstream = "git://github.com/WebPlatformForEmbedded/WPEBackend-rdk.git;protocol=https;branch=master"
-SRCREV:class-devupstream = "f0475a271211efc501fc810304b5dc69a5e12bbb"
+SRCREV:class-devupstream = "108e4ab0da043421202e3ef64e0a38d1db8b82ee"
 
 RPROVIDES:${PN}:append:class-devupstream = "virtual/wpebackend"


### PR DESCRIPTION
* Add new PACKAGECONFIG options for new input backends available to CMake.

* Fix also the `libudev` dependency name. In Yocto 4.2 (Mickledore) that dependency is not longer available with that name. Instead make it depend on `udev` that is the generic name for any of the providers of `PREFERRED_PROVIDER_udev` (systemd, libeudev, etc).