### PR TITLE
Update and Fix WPEWebkit Compilation

### DIFF
--- a/recipes-browser/wpewebkit/wpewebkit/0001-WPE-Fix-build-without-USE_GBM.patch
+++ b/recipes-browser/wpewebkit/wpewebkit/0001-WPE-Fix-build-without-USE_GBM.patch
@@ -1,0 +1,36 @@
+From 5aaf70fede8acf290deea468a4e45de77c691341 Mon Sep 17 00:00:00 2001
+From: Olivier Blin <olivier.blin@softathome.com>
+Date: Tue, 29 Aug 2023 08:46:16 -0700
+Subject: [PATCH] Cherry-pick 260527.430@eng/2.40-WPE-Fix-build-without-USE-GBM
+ (5375e5bb05a7). <bug>
+
+    [WPE] Fix build without USE(GBM)
+
+    Reviewed by Michael Catanzaro.
+
+    There was a USE_GBM leftover, while it is now a conditional option.
+
+    Cherry-picks 263069@main ("[GTK][WPE] Unify USE(GBM) and USE(LIBGBM)")
+    and 263491@main ("[WPE] Make libgbm and libdrm conditional dependencies")
+    have been applied in a different order than in main branch.
+
+    Canonical link: https://commits.webkit.org/260527.430@webkitglib/2.40
+
+Canonical link: https://commits.webkit.org/260527.431@webkitglib/2.40
+Upstream-Status: Backport [https://github.com/WebKit/WebKit/commit/b8ffa14eaad872df3a0de481297ee5c760539217]
+---
+ Source/cmake/OptionsWPE.cmake | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/Source/cmake/OptionsWPE.cmake b/Source/cmake/OptionsWPE.cmake
+index 8077c4706a098..f96959a0bc01d 100644
+--- a/Source/cmake/OptionsWPE.cmake
++++ b/Source/cmake/OptionsWPE.cmake
+@@ -359,7 +359,6 @@ SET_AND_EXPOSE_TO_BUILD(HAVE_ACCESSIBILITY ${ENABLE_ACCESSIBILITY})
+ SET_AND_EXPOSE_TO_BUILD(USE_ATSPI ${ENABLE_ACCESSIBILITY})
+ SET_AND_EXPOSE_TO_BUILD(USE_CAIRO TRUE)
+ SET_AND_EXPOSE_TO_BUILD(USE_EGL TRUE)
+-SET_AND_EXPOSE_TO_BUILD(USE_GBM TRUE)
+ SET_AND_EXPOSE_TO_BUILD(USE_GCRYPT TRUE)
+ SET_AND_EXPOSE_TO_BUILD(USE_LIBEPOXY TRUE)
+ SET_AND_EXPOSE_TO_BUILD(USE_LIBWPE TRUE)

--- a/recipes-browser/wpewebkit/wpewebkit_2.40.5.bb
+++ b/recipes-browser/wpewebkit/wpewebkit_2.40.5.bb
@@ -5,6 +5,7 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
 SRC_URI = "https://wpewebkit.org/releases/${BPN}-${PV}.tar.xz;name=tarball \
            file://0001-FELightningNEON.cpp-fails-to-build-NEON-fast-path-se.patch \
+           file://0001-WPE-Fix-build-without-USE_GBM.patch \
           "
 
 SRC_URI[tarball.sha256sum] = "4c658d3049c50e98b12fd6623ec42772f25a99cc1c05b5347a10a8633c266733"

--- a/recipes-browser/wpewebkit/wpewebkit_2.40.5.bb
+++ b/recipes-browser/wpewebkit/wpewebkit_2.40.5.bb
@@ -7,7 +7,7 @@ SRC_URI = "https://wpewebkit.org/releases/${BPN}-${PV}.tar.xz;name=tarball \
            file://0001-FELightningNEON.cpp-fails-to-build-NEON-fast-path-se.patch \
           "
 
-SRC_URI[tarball.sha256sum] = "05b6a9cb1d7d03485e0dc41b2a8e6f99a36aea23d32ba3ecb38d0d6860747ada"
+SRC_URI[tarball.sha256sum] = "4c658d3049c50e98b12fd6623ec42772f25a99cc1c05b5347a10a8633c266733"
 
 DEPENDS += " libwpe"
 RCONFLICTS:${PN} = "libwpe (< 1.12)"


### PR DESCRIPTION

This Pull Request addresses two primary issues to enhance WPEWebkit support on the IMX6 platform:

1. **Add patch to fix cmake for wpewebkit**: Introduces a new patch that modifies the cmake file for WPEWebkit. This allows for the compilation without the `USE_GBM` macro, which is otherwise declared by default inside the cmake and cannot be disabled during compilation. The patch is located at `recipes-browser/wpewebkit/wpewebkit/0001-WPE-Fix-build-without-USE_GBM.patch`.

2. **Update WPEWebkit Recipe to Version 2.40.5**: This updates WPEWebkit from version 2.40.3 to 2.40.5, incorporating the latest features and bug fixes.

#### Why this PR is needed:

- Enables the ability to compile WPEWebkit without the `USE_GBM` macro, which is declared inside the cmake and prevents its deactivation during the build.
- Keeps WPEWebkit up-to-date with the latest version for additional performance improvements and fixes.

#### Testing:

1. Compile WPEWebkit for IMX6, applying the new patch and updated recipe.
2. Verify that WPEWebkit operates as expected without the `USE_GBM` macro.