### PR TITLE
Bump versions

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -17,4 +17,4 @@ BBFILE_PRIORITY_webkit = "7"
 BB_DANGLINGAPPENDS_WARNONLY = "true"
 
 # Support from the current actively maintained LTS Yocto release
-LAYERSERIES_COMPAT_webkit = "dunfell gatesgarth hardknott honister kirkstone langdale mickledore"
+LAYERSERIES_COMPAT_webkit = "dunfell gatesgarth hardknott honister kirkstone langdale mickledore nanbield"

--- a/recipes-browser/cog/cog-meson.inc
+++ b/recipes-browser/cog/cog-meson.inc
@@ -4,7 +4,7 @@ PACKAGECONFIG[dbus] = "-Dcog_dbus_control=system -Dcog_dbus_system_owner=${COG_D
 PACKAGECONFIG[drm] = ",,wpebackend-fdo libdrm virtual/libgbm libinput"
 PACKAGECONFIG[gtk4] = ",,gtk4"
 PACKAGECONFIG[headless] = ",,wpebackend-fdo"
-PACKAGECONFIG[soup2] = "-Dsoup2=enabled,-Dsoup2=disabled,libsoup-2.4"
+#PACKAGECONFIG[soup2] = "-Dsoup2=enabled,-Dsoup2=disabled,libsoup-2.4"
 PACKAGECONFIG[weston-direct-display] = "-Dwayland_weston_direct_display=true,-Dwayland_weston_direct_display=false,weston"
 PACKAGECONFIG[wl] = ",,wpebackend-fdo"
 

--- a/recipes-browser/cog/cog_0.18.1.bb
+++ b/recipes-browser/cog/cog_0.18.1.bb
@@ -1,0 +1,11 @@
+require cog.inc
+require cog-meson.inc
+
+DEFAULT_PREFERENCE = "-1"
+
+SRC_URI[sha256sum] = "72e3a84052b459e2d53d0e8b947f20e27bf5d8049766c4c1594eb9c6b6cf7ab3"
+
+# Required since https://github.com/Igalia/cog/commit/48dfac2ba637e223eeea1b289526d0f51e39ab88
+DEPENDS:append = " libxkbcommon"
+
+RDEPENDS:${PN} += "wpewebkit (>= 2.36)"

--- a/recipes-browser/wpebackend-fdo/wpebackend-fdo_1.14.2.bb
+++ b/recipes-browser/wpebackend-fdo/wpebackend-fdo_1.14.2.bb
@@ -1,0 +1,3 @@
+require wpebackend-fdo.inc
+
+SRC_URI[sha256sum] = "93c9766ae9864eeaeaee2b0a74f22cbca08df42c1a1bdb55b086f2528e380d38"

--- a/recipes-browser/wpewebkit/wpewebkit.inc
+++ b/recipes-browser/wpewebkit/wpewebkit.inc
@@ -56,7 +56,7 @@ CMAKE_QT5_OECONF = "\
 
 export WK_USE_CCACHE="NO"
 
-PACKAGECONFIG ??= "jit dfg-jit mediasource video webaudio webcrypto woff2 gst_gl \
+PACKAGECONFIG ??= "jit dfg-jit mediasource video webcrypto woff2 gst_gl \
                    remote-inspector openjpeg unified-builds service-worker \
                    ${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'journald', '' ,d)} \
                    avif \

--- a/recipes-browser/wpewebkit/wpewebkit_2.42.2.bb
+++ b/recipes-browser/wpewebkit/wpewebkit_2.42.2.bb
@@ -1,0 +1,35 @@
+require wpewebkit.inc
+require conf/include/devupstream.inc
+
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
+
+SRC_URI = "https://wpewebkit.org/releases/${BPN}-${PV}.tar.xz;name=tarball \
+           file://0001-FELightningNEON.cpp-fails-to-build-NEON-fast-path-se.patch \
+          "
+
+SRC_URI[tarball.sha256sum] = "df99bbc7007df60d77821e4c169312464f145c8aa6e34398a43da36a857285e8"
+
+DEPENDS += " libwpe"
+RCONFLICTS:${PN} = "libwpe (< 1.12)"
+
+# documentation: Needed from 2.38
+PACKAGECONFIG[documentation] = "-DENABLE_DOCUMENTATION=ON,-DENABLE_DOCUMENTATION=OFF, gi-docgen-native gi-docgen"
+
+# introspection: Needed from 2.38
+PACKAGECONFIG[introspection] = "-DENABLE_INTROSPECTION=ON,-DENABLE_INTROSPECTION=OFF, gobject-introspection-native"
+
+# webgl2: Activated by default from >2.38
+PACKAGECONFIG:append = " webgl2"
+
+# TODO: documentation and introspection are disabled by default because the are
+# causing cross-compiling build errors
+# PACKAGECONFIG:append = " ${@bb.utils.contains('DISTRO_FEATURES', 'api-documentation', 'documentation', '' ,d)} introspection"
+
+# Layer-Based SVG Engine
+PACKAGECONFIG[lbse] = "-DENABLE_LAYER_BASED_SVG_ENGINE=ON,-DENABLE_LAYER_BASED_SVG_ENGINE=OFF, "
+
+# unifdef-native: Needed since >2.38.
+DEPENDS:append = " unifdef-native"
+
+#jpegxl
+DEPENDS:append = " libjxl"


### PR DESCRIPTION
Bump:
wpewebkit 2.42.2
backend-fdo 1.14.2
libwpe 1.14.1
cog 0.18.1

I removed soup2 and webaudio to make it fit. Can maybe more polished, but I leave it to someon who knows the internals more