### PR TITLE
cog: Fix the launch in Weston kiosk mode

### DIFF
--- a/recipes-browser/cog/cog/0002-wl-Do-not-attach-frames-with-invalid-size-to-the-sur.patch
+++ b/recipes-browser/cog/cog/0002-wl-Do-not-attach-frames-with-invalid-size-to-the-sur.patch
@@ -1,0 +1,83 @@
+From 65b6a9a26f4c8cf411507fd9eede62fa923f638f Mon Sep 17 00:00:00 2001
+From: Adrian Perez de Castro <aperez@igalia.com>
+Date: Wed, 28 Feb 2024 14:49:58 -0300
+Subject: [PATCH] wl: Do not attach frames with invalid size to the surface
+
+Skip frames which do not match the size of the output surface, in order to
+avoid a Wayland protocol error resulting from mismatched sizes. This can
+happen, for example, after requesting that the surface is maximized, while
+the view backend has already produced some frames, but the change of size
+has not been yet noted by WebKit. In these cases we can safely skip using
+the frames but they still need to be ACK'd in order to let WebKit continue
+producing new ones, which eventually will arrive in the desired size.
+
+Related issue #537
+
+Upstream-Status: Backport [https://github.com/Igalia/cog/pull/539/commits/f6b27e46e3fb3e453860acc8956efd80c5361fb2]
+Signed-off-by: Fabio Estevam <festevam@denx.de>
+---
+ platform/wayland/cog-platform-wl.c | 34 ++++++++++++++++++++++++++----
+ 1 file changed, 30 insertions(+), 4 deletions(-)
+
+diff --git a/platform/wayland/cog-platform-wl.c b/platform/wayland/cog-platform-wl.c
+index dbbeae9cb91f..5c75ab10900c 100644
+--- a/platform/wayland/cog-platform-wl.c
++++ b/platform/wayland/cog-platform-wl.c
+@@ -1654,6 +1654,20 @@ static const struct wl_buffer_listener dmabuf_buffer_listener = {
+ static void
+ on_export_wl_egl_image(void *data, struct wpe_fdo_egl_exported_image *image)
+ {
++    const uint32_t surface_pixel_width = wl_data.current_output.scale * win_data.width;
++    const uint32_t surface_pixel_height = wl_data.current_output.scale * win_data.height;
++
++    if (surface_pixel_width != wpe_fdo_egl_exported_image_get_width(image) ||
++        surface_pixel_height != wpe_fdo_egl_exported_image_get_height(image)) {
++        g_debug("Exported FDO EGL image size %" PRIu32 "x%" PRIu32 ", does not match surface size %" PRIu32 "x%" PRIu32
++                ", skipping.",
++                wpe_fdo_egl_exported_image_get_width(image), wpe_fdo_egl_exported_image_get_height(image),
++                surface_pixel_width, surface_pixel_width);
++        wpe_view_backend_exportable_fdo_dispatch_frame_complete(wpe_host_data.exportable);
++        wpe_view_backend_exportable_fdo_egl_dispatch_release_exported_image(wpe_host_data.exportable, image);
++        return;
++    }
++
+     wpe_view_data.image = image;
+ 
+     if (wpe_view_data.should_update_opaque_region) {
+@@ -1682,10 +1696,7 @@ on_export_wl_egl_image(void *data, struct wpe_fdo_egl_exported_image *image)
+     wl_buffer_add_listener(wpe_view_data.buffer, &buffer_listener, image);
+ 
+     wl_surface_attach (win_data.wl_surface, wpe_view_data.buffer, 0, 0);
+-    wl_surface_damage (win_data.wl_surface,
+-                       0, 0,
+-                       win_data.width * wl_data.current_output.scale,
+-                       win_data.height * wl_data.current_output.scale);
++    wl_surface_damage(win_data.wl_surface, 0, 0, surface_pixel_width, surface_pixel_height);
+ 
+     request_frame ();
+ 
+@@ -1798,6 +1809,21 @@ on_export_shm_buffer (void* data, struct wpe_fdo_shm_exported_buffer* exported_b
+     struct wl_resource *exported_resource = wpe_fdo_shm_exported_buffer_get_resource (exported_buffer);
+     struct wl_shm_buffer *exported_shm_buffer = wpe_fdo_shm_exported_buffer_get_shm_buffer (exported_buffer);
+ 
++    const uint32_t surface_pixel_width = wl_data.current_output.scale * win_data.width;
++    const uint32_t surface_pixel_height = wl_data.current_output.scale * win_data.height;
++
++    if (surface_pixel_width != wl_shm_buffer_get_width(exported_shm_buffer) ||
++        surface_pixel_height != wl_shm_buffer_get_height(exported_shm_buffer)) {
++        g_debug("Exported SHM buffer size %" PRIu32 "x%" PRIu32 ", does not match surface size %" PRIu32 "x%" PRIu32
++                ", skipping.",
++                wl_shm_buffer_get_width(exported_shm_buffer), wl_shm_buffer_get_width(exported_shm_buffer),
++                surface_pixel_width, surface_pixel_width);
++        wpe_view_backend_exportable_fdo_dispatch_frame_complete(wpe_host_data.exportable);
++        wpe_view_backend_exportable_fdo_egl_dispatch_release_shm_exported_buffer(wpe_host_data.exportable,
++                                                                                 exported_buffer);
++        return;
++    }
++
+     struct shm_buffer *buffer = shm_buffer_for_resource (exported_resource);
+     if (!buffer) {
+         int32_t width;
+-- 
+2.34.1
+

--- a/recipes-browser/cog/cog_0.14.1.bb
+++ b/recipes-browser/cog/cog_0.14.1.bb
@@ -1,6 +1,7 @@
 require cog.inc
 require cog-cmake.inc
 
+SRC_URI:append = " file://0002-wl-Do-not-attach-frames-with-invalid-size-to-the-sur.patch"
 SRC_URI[sha256sum] = "fb91104e25e1dde27189c91c70acc356e387f47acebaa8997e01ce5879c3a600"
 
 # Required since https://github.com/Igalia/cog/commit/48dfac2ba637e223eeea1b289526d0f51e39ab88


### PR DESCRIPTION
When launching cog in Weston kiosk mode on a board with a display resolution of 1024 x 600, the following error is seen:

xdg_wm_base@10: error 4: xdg_surface geometry (1024 x 768) is larger than the configured fullscreen state (1024 x 600)

Fix it by backporting an upstream cog commit so that it can be launched successfully.