### PR TITLE
Fix build failure on scarthgap.

### DIFF
--- a/conf/distro/webkitdevci.conf
+++ b/conf/distro/webkitdevci.conf
@@ -26,7 +26,7 @@ DISTRO_VERSION:append = "_${WEBKIT_CROSS_VERSION}"
 DISTROOVERRIDES:append = " poky:linuxstdbase"
 
 # Distro features
-DISTRO_FEATURES:append = " opengl egl pam systemd"
+DISTRO_FEATURES:append = " opengl egl pam systemd usrmerge"
 DISTRO_FEATURES:remove = "ptest"
 DISTRO_FEATURES_NATIVESDK:append = " wayland"
 


### PR DESCRIPTION
When using meta-webkit with scarthgap branch, the build fails, complaining about the missing 'usrmerge' DISTRO_FEATURE -- enable it to fix builds with newer Yocto releases.