### PR TITLE
wpewebkit: Add a "release-with-debug-info" knob.

### DIFF
--- a/recipes-browser/wpewebkit/wpewebkit.inc
+++ b/recipes-browser/wpewebkit/wpewebkit.inc
@@ -65,6 +65,7 @@ PACKAGECONFIG ??= "jit dfg-jit mediasource mediastream video webaudio webcrypto 
                   "
 
 PACKAGECONFIG[reduce-size] = "-DCMAKE_BUILD_TYPE=MinSizeRel,-DCMAKE_BUILD_TYPE=Release,,"
+PACKAGECONFIG[release-with-debug-info] = "-DCMAKE_BUILD_TYPE=RelWithDebInfo,-DCMAKE_BUILD_TYPE=Release,,"
 # WPE features
 PACKAGECONFIG[accessibility] = "-DENABLE_ACCESSIBILITY=ON,-DENABLE_ACCESSIBILITY=OFF,atk at-spi2-atk"
 PACKAGECONFIG[avif] = "-DUSE_AVIF=ON,-DUSE_AVIF=OFF,libavif"


### PR DESCRIPTION
Add a new PACKAGECONFIG option to allow building a WebKit release build including debug information (CMAKE_BUILD_TYPE=RelWithDebInfo).