### PR TITLE
wpewebkit: Bump to version 2.44.4

### DIFF
--- a/recipes-browser/wpewebkit/wpewebkit_2.44.4.bb
+++ b/recipes-browser/wpewebkit/wpewebkit_2.44.4.bb
@@ -7,7 +7,7 @@ SRC_URI = "https://wpewebkit.org/releases/${BPN}-${PV}.tar.xz;name=tarball \
            file://0002-Activate-HAVE_MISSING_STD_FILESYSTEM_PATH_CONSTRUCTO.patch \
           "
 
-SRC_URI[tarball.sha256sum] = "2c9fbf4fcf8884d34102283e2b008ce0b0bc2cf07de78f564a8b34347e7bc19b"
+SRC_URI[tarball.sha256sum] = "cd6042c63a6f883cc1586e5cea94e846aaaee6a864c14988e8af4ef4f362ba3b"
 
 SRC_URI:class-devupstream = "git://github.com/WebKit/WebKit.git;protocol=https;branch=main"
 
@@ -18,8 +18,7 @@ PACKAGECONFIG[accessibility] = "-DUSE_ATK=ON,-DUSE_ATK=OFF,atk at-spi2-atk"
 # libbacktrace. Since 2.44+
 PACKAGECONFIG[libbacktrace] = "-DUSE_LIBBACKTRACE=ON,-DUSE_LIBBACKTRACE=OFF,libbacktrace"
 
-# The WPE 2.44.X branch was forked from the main branch in this commit
-SRCREV:class-devupstream = "39f0dc749a8d05eb34bbbcf497b5e44f4ff9e68d"
+SRCREV:class-devupstream = "fd73f137dcc66fd5c7146c3d9578346e77ae6d0a"
 
 PACKAGECONFIG:append = " libbacktrace"
 


### PR DESCRIPTION
Changes:
 
* Add quirk to allow totale.rosettastone.com to load properly.
* Decrease input notifications for gamepad inputs.
* Disable the gst-libav AAC decoder.
* Make gamepads visible on axis movements, and not only on button presses.
* Make user scripts and style sheets visible in the Web Inspector.
* Undeprecate console message API and make it available in 2022 API.
* Use optimized assembler BoringSSL modules with USE_LIBWEBRTC enabled.
* Use the geolocation portal where available, with the existing Geoclue as fallback if the portal is not usable.
* Fix accelerated images dissapearing after scrolling.
* Fix mouse location in WebDriver when output device scaling is in effect.
* Fix not being able to jump-to-source in Web Inspector canvas traces.
* Fix not being able to scroll list of WebGL shader programs in the Web Inspector.
* Fix the build with GBM support when the WPEPlatform library is disabled.
* Fix linker relocation errors on Debug/RelWithDebInfo builds.
* Fix crashes when built with Clang with Link-Time Optimization (LTO).
* Fix the build on 32-bit ARM with USE_LIBWEBRTC enabled.
* Fix the build with ENABLE_WEBAUDIO disabled.
* Fix touch input event propagation.
* Fix video flickering with DMA-BUF sink.
* Fix web process cache suspend/resume when sandbox is enabled.
* Fix several crashes and rendering issues.

Release notes:

- https://wpewebkit.org/release/wpewebkit-2.44.4.html
- https://wpewebkit.org/release/wpewebkit-2.44.3.html
- https://wpewebkit.org/release/wpewebkit-2.44.2.html
