### PR TITLE
webkitgtk: Bump to version 2.44.4

### DIFF
--- a/recipes-browser/webkitgtk/webkitgtk_2.44.4.bb
+++ b/recipes-browser/webkitgtk/webkitgtk_2.44.4.bb
@@ -32,7 +32,7 @@ SRC_URI = " \
     file://0001-Activate-HAVE_MISSING_STD_FILESYSTEM_PATH_CONSTRUCTO.patch \
 "
 
-SRC_URI[tarball.sha256sum] = "425b1459b0f04d0600c78d1abb5e7edfa3c060a420f8b231e9a6a2d5d29c5561"
+SRC_URI[tarball.sha256sum] = "2ce4ec1b78413035037aba8326b31ed72696626b7bea7bace5e46ac0d8cbe796"
 
 RRECOMMENDS:${PN} = "${PN}-bin \
                      ca-certificates \


### PR DESCRIPTION
Changes:

* Add quirk to allow totale.rosettastone.com to load properly.
* Decrease input notifications for gamepad inputs.
* Disable the gst-libav AAC decoder.
* Make gamepads visible on axis movements, and not only on button presses.
* Make user scripts and style sheets visible in the Web Inspector.
* Undeprecate console message API and make it available in 2022 API.
* Use optimized assembler BoringSSL modules with USE_LIBWEBRTC enabled.
* Use the geolocation portal where available, with the existing Geoclue as fallback if the portal is not usable.
* Fix accelerated images dissapearing after scrolling.
* Fix mouse location in WebDriver when output device scaling is in effect.
* Fix not being able to jump-to-source in Web Inspector canvas traces.
* Fix not being able to scroll list of WebGL shader programs in the Web Inspector.
* Fix linker relocation errors on Debug/RelWithDebInfo builds.
* Fix crashes when built with Clang with Link-Time Optimization (LTO).
* Fix the build on 32-bit ARM with USE_LIBWEBRTC enabled.
* Fix the build with ENABLE_WEBAUDIO disabled.
* Fix touch input event propagation.
* Fix video flickering with DMA-BUF sink.
* Fix web process cache suspend/resume when sandbox is enabled.
* Fix pointer lock on X11.
* Fix movement delta on mouse events in GTK3.
* Fix several crashes and rendering issues.

Release notes:

* https://webkitgtk.org/release/webkitgtk-2.44.4.html
* https://webkitgtk.org/2024/08/13/webkitgtk2.44.3-released.html
* https://webkitgtk.org/2024/05/16/webkitgtk2.44.2-released.html