### PR TITLE
cog_0.16: Fix the launch in Weston kiosk mode

### DIFF
--- a/recipes-browser/cog/cog_0.16.1.bb
+++ b/recipes-browser/cog/cog_0.16.1.bb
@@ -4,6 +4,7 @@ require conf/include/devupstream.inc
 
 DEFAULT_PREFERENCE = "-1"
 
+SRC_URI:append = " file://0002-wl-Do-not-attach-frames-with-invalid-size-to-the-sur.patch"
 SRC_URI[sha256sum] = "37c5f14123b8dcf077839f6c60f0d721d2a91bb37829e796f420126e6b0d38b5"
 
 SRC_URI:class-devupstream = "git://github.com/Igalia/cog.git;protocol=https;branch=cog-0.16"


### PR DESCRIPTION
When launching cog in Weston kiosk mode on a board with a display resolution of 1024 x 600, the following error is seen:

xdg_wm_base@10: error 4: xdg_surface geometry (1024 x 768) is larger than the configured fullscreen state (1024 x 600)

Fix it by backporting an upstream cog commit so that it can be launched successfully.

This has already been fixed in the cog_0.14.1 recipe. Do the same for the cog_0.16.1 recipe.