### PR TITLE
wpewebkit: inherit feature_check

### DIFF
--- a/recipes-browser/wpewebkit/wpewebkit.inc
+++ b/recipes-browser/wpewebkit/wpewebkit.inc
@@ -17,7 +17,7 @@ DEPENDS:append = " \
     libwpe virtual/wpebackend \
 "
 
-inherit cmake pkgconfig perlnative python3native
+inherit cmake features_check pkgconfig perlnative python3native
 
 # We cannot inherit cmake_qt5 because it will unconditionally add packages
 # to DEPENDS which cannot be removed later depending on the options chosen


### PR DESCRIPTION
otherwise setting REQUIRED_DISTRO_FEATURES has no effect. Fixes build warning;

wpewebkit-2.46.1-r0 do_package_qa: QA Issue: wpewebkit: recipe doesn't inherit features_check [unhandled-features-check]