### PR TITLE
wpewebkit: Add patches for build fixes related to ENABLE(VIDEO) and Fix build for cortexa8hf-neon

### DIFF
--- a/recipes-browser/wpewebkit/wpewebkit/0001-Build-fixes-for-ENABLE-VIDEO-https-bugs.webkit.org-s.patch
+++ b/recipes-browser/wpewebkit/wpewebkit/0001-Build-fixes-for-ENABLE-VIDEO-https-bugs.webkit.org-s.patch
@@ -1,0 +1,305 @@
+From 38fa12920b01855f7819c6b1fb3cb09ca8a9e947 Mon Sep 17 00:00:00 2001
+From: Olivier Blin <olivier.blin@softathome.com>
+Date: Mon, 14 Oct 2024 01:41:01 -0700
+Subject: Build fixes for !ENABLE(VIDEO)
+ https://bugs.webkit.org/show_bug.cgi?id=281253
+
+Reviewed by Philippe Normand.
+
+* Source/WebCore/Modules/WebGPU/GPUDevice.h:
+    Flag variables only used with ENABLE(VIDEO)
+        m_videoElementToExternalTextureMap
+        m_previouslyImportedExternalTexture
+        m_lastCreatedExternalTextureBindGroup
+
+* Source/WebCore/css/CSSPseudoSelectors.json:
+    Flag -internal-in-window-fullscreen to avoid warning in SelectorChecker switch
+
+* Source/WebCore/dom/Document.cpp:
+(WebCore::eventTargetElementForDocument):
+    Flag HTMLVideoElement check
+
+* Source/WebCore/dom/FullscreenManager.cpp:
+(WebCore::FullscreenManager::willEnterFullscreen):
+    Fix unused variable warning
+
+* Source/WebCore/page/DiagnosticLoggingKeys.cpp:
+(WebCore::DiagnosticLoggingKeys::mediaElementSourceTypeDiagnosticLoggingKey): Deleted.
+* Source/WebCore/page/DiagnosticLoggingKeys.h:
+    Remove unused mediaElementSourceTypeDiagnosticLoggingKey after 282029@main
+
+* Source/WebCore/page/ElementTargetingController.cpp:
+(WebCore::hasAudibleMedia):
+(WebCore::urlForElement):
+    Flag HTMLMediaElement usage
+
+* Source/WebCore/rendering/updating/RenderTreeBuilder.cpp:
+(WebCore::RenderTreeBuilder::attachToRenderElementInternal):
+    Flag RenderVideo check
+
+* Source/WebCore/testing/Internals.cpp:
+* Source/WebCore/testing/Internals.h:
+* Source/WebCore/testing/Internals.idl:
+    Make isEffectivelyMuted conditional since it uses HTMLMediaElement
+
+* Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp:
+(WebKit::GPUConnectionToWebProcess::didClose):
+    m_remoteMediaResourceManager is defined only with ENABLE(VIDEO)
+
+* Source/WebKit/WebProcess/GPU/media/gstreamer/VideoLayerRemoteGStreamer.cpp:
+    Flag the whole file under ENABLE(VIDEO) like other media GPU Process files
+
+Canonical link: https://commits.webkit.org/285114@main
+---
+ Source/WebCore/Modules/WebGPU/GPUDevice.h     |  3 ++-
+ Source/WebCore/css/CSSPseudoSelectors.json    |  2 +-
+ Source/WebCore/dom/Document.cpp               |  2 ++
+ Source/WebCore/dom/FullscreenManager.cpp      |  4 +++
+ Source/WebCore/page/DiagnosticLoggingKeys.cpp | 25 -------------------
+ Source/WebCore/page/DiagnosticLoggingKeys.h   |  2 --
+ .../page/ElementTargetingController.cpp       |  6 +++++
+ .../rendering/updating/RenderTreeBuilder.cpp  |  9 ++++---
+ Source/WebCore/testing/Internals.cpp          |  2 ++
+ Source/WebCore/testing/Internals.h            |  2 ++
+ Source/WebCore/testing/Internals.idl          |  2 +-
+ .../GPUProcess/GPUConnectionToWebProcess.cpp  |  2 ++
+ .../gstreamer/VideoLayerRemoteGStreamer.cpp   |  2 +-
+ 13 files changed, 29 insertions(+), 34 deletions(-)
+
+diff --git a/Source/WebCore/Modules/WebGPU/GPUDevice.h b/Source/WebCore/Modules/WebGPU/GPUDevice.h
+index 5dae0648..a869f0b4 100644
+--- a/Source/WebCore/Modules/WebGPU/GPUDevice.h
++++ b/Source/WebCore/Modules/WebGPU/GPUDevice.h
+@@ -172,11 +172,12 @@ private:
+ 
+ #if ENABLE(VIDEO)
+     GPUExternalTexture* externalTextureForDescriptor(const GPUExternalTextureDescriptor&);
+-#endif
+ 
+     WeakHashMap<HTMLVideoElement, WeakPtr<GPUExternalTexture>> m_videoElementToExternalTextureMap;
+     std::pair<RefPtr<HTMLVideoElement>, RefPtr<GPUExternalTexture>> m_previouslyImportedExternalTexture;
+     std::pair<Vector<GPUBindGroupEntry>, RefPtr<GPUBindGroup>> m_lastCreatedExternalTextureBindGroup;
++#endif
++
+     bool m_waitingForDeviceLostPromise { false };
+ };
+ 
+diff --git a/Source/WebCore/css/CSSPseudoSelectors.json b/Source/WebCore/css/CSSPseudoSelectors.json
+index 1eb73816..73bfcecd 100644
+--- a/Source/WebCore/css/CSSPseudoSelectors.json
++++ b/Source/WebCore/css/CSSPseudoSelectors.json
+@@ -47,7 +47,7 @@
+         },
+         "-internal-html-document": {},
+         "-internal-in-window-fullscreen": {
+-            "conditional": "ENABLE(FULLSCREEN_API)"
++            "conditional": "ENABLE(FULLSCREEN_API) && ENABLE(VIDEO)"
+         },
+         "-internal-media-document": {},
+         "-webkit-any": {
+diff --git a/Source/WebCore/dom/Document.cpp b/Source/WebCore/dom/Document.cpp
+index c13f0a7c..e3d9fc39 100644
+--- a/Source/WebCore/dom/Document.cpp
++++ b/Source/WebCore/dom/Document.cpp
+@@ -8692,8 +8692,10 @@ Element* eventTargetElementForDocument(Document* document)
+     if (!document)
+         return nullptr;
+ #if ENABLE(FULLSCREEN_API)
++#if ENABLE(VIDEO)
+     if (CheckedPtr fullscreenManager = document->fullscreenManagerIfExists(); fullscreenManager && fullscreenManager->isFullscreen() && is<HTMLVideoElement>(fullscreenManager->currentFullscreenElement()))
+         return fullscreenManager->currentFullscreenElement();
++#endif
+ #endif
+     Element* element = document->focusedElement();
+     if (!element) {
+diff --git a/Source/WebCore/dom/FullscreenManager.cpp b/Source/WebCore/dom/FullscreenManager.cpp
+index ee052eb1..67672b7e 100644
+--- a/Source/WebCore/dom/FullscreenManager.cpp
++++ b/Source/WebCore/dom/FullscreenManager.cpp
+@@ -459,6 +459,10 @@ bool FullscreenManager::isFullscreenEnabled() const
+ 
+ bool FullscreenManager::willEnterFullscreen(Element& element, HTMLMediaElementEnums::VideoFullscreenMode mode)
+ {
++#if !ENABLE(VIDEO)
++    UNUSED_PARAM(mode);
++#endif
++
+     if (backForwardCacheState() != Document::NotInBackForwardCache) {
+         ERROR_LOG(LOGIDENTIFIER, "Document in the BackForwardCache; bailing");
+         return false;
+diff --git a/Source/WebCore/page/DiagnosticLoggingKeys.cpp b/Source/WebCore/page/DiagnosticLoggingKeys.cpp
+index 60b553d6..103f2a2b 100644
+--- a/Source/WebCore/page/DiagnosticLoggingKeys.cpp
++++ b/Source/WebCore/page/DiagnosticLoggingKeys.cpp
+@@ -791,30 +791,5 @@ String DiagnosticLoggingKeys::audioCodecKey()
+     return "audioCodec"_s;
+ }
+ 
+-String DiagnosticLoggingKeys::mediaElementSourceTypeDiagnosticLoggingKey(HTMLMediaElementSourceType sourceType)
+-{
+-    switch (sourceType) {
+-    case HTMLMediaElementSourceType::File:
+-        return "file"_s;
+-    case HTMLMediaElementSourceType::HLS:
+-        return "hls"_s;
+-    case HTMLMediaElementSourceType::MediaSource:
+-        return "mediaSource"_s;
+-    case HTMLMediaElementSourceType::ManagedMediaSource:
+-        return "managedMediaSource"_s;
+-    case HTMLMediaElementSourceType::MediaStream:
+-        return "mediaStream"_s;
+-    case HTMLMediaElementSourceType::LiveStream:
+-        return "liveStream"_s;
+-    case HTMLMediaElementSourceType::StoredStream:
+-        return "storedStream"_s;
+-    }
+-
+-    ASSERT_NOT_REACHED();
+-    return nullString();
+-}
+-
+-
+-
+ } // namespace WebCore
+ 
+diff --git a/Source/WebCore/page/DiagnosticLoggingKeys.h b/Source/WebCore/page/DiagnosticLoggingKeys.h
+index 77ac008e..29883230 100644
+--- a/Source/WebCore/page/DiagnosticLoggingKeys.h
++++ b/Source/WebCore/page/DiagnosticLoggingKeys.h
+@@ -181,8 +181,6 @@ public:
+     WEBCORE_EXPORT static String memoryUsageToDiagnosticLoggingKey(uint64_t memoryUsage);
+     WEBCORE_EXPORT static String foregroundCPUUsageToDiagnosticLoggingKey(double cpuUsage);
+     WEBCORE_EXPORT static String backgroundCPUUsageToDiagnosticLoggingKey(double cpuUsage);
+-
+-    static String mediaElementSourceTypeDiagnosticLoggingKey(HTMLMediaElementSourceType);
+ };
+ 
+ } // namespace WebCore
+diff --git a/Source/WebCore/page/ElementTargetingController.cpp b/Source/WebCore/page/ElementTargetingController.cpp
+index 34d2d174..5ce89a41 100644
+--- a/Source/WebCore/page/ElementTargetingController.cpp
++++ b/Source/WebCore/page/ElementTargetingController.cpp
+@@ -616,6 +616,7 @@ static String searchableTextForTarget(Element& target)
+ 
+ static bool hasAudibleMedia(const Element& element)
+ {
++#if ENABLE(VIDEO)
+     if (RefPtr media = dynamicDowncast<HTMLMediaElement>(element))
+         return media->isAudible();
+ 
+@@ -628,6 +629,9 @@ static bool hasAudibleMedia(const Element& element)
+         if (hasAudibleMedia(documentElement))
+             return true;
+     }
++#else
++    UNUSED_PARAM(element);
++#endif
+ 
+     return false;
+ }
+@@ -640,8 +644,10 @@ static URL urlForElement(const Element& element)
+     if (RefPtr image = dynamicDowncast<HTMLImageElement>(element))
+         return image->currentURL();
+ 
++#if ENABLE(VIDEO)
+     if (RefPtr media = dynamicDowncast<HTMLMediaElement>(element))
+         return media->currentSrc();
++#endif
+ 
+     if (CheckedPtr renderer = element.renderer()) {
+         if (auto& style = renderer->style(); style.hasBackgroundImage()) {
+diff --git a/Source/WebCore/rendering/updating/RenderTreeBuilder.cpp b/Source/WebCore/rendering/updating/RenderTreeBuilder.cpp
+index a0f9e590..a56e2c39 100644
+--- a/Source/WebCore/rendering/updating/RenderTreeBuilder.cpp
++++ b/Source/WebCore/rendering/updating/RenderTreeBuilder.cpp
+@@ -480,9 +480,12 @@ void RenderTreeBuilder::attachToRenderElementInternal(RenderElement& parent, Ren
+             // FIXME: Introduce a dirty bit to bridge the gap between parent and containing block which would
+             // not trigger layout but a simple traversal all the way to the direct parent and also expand it non-direct parent cases.
+             // FIXME: RenderVideo's setNeedsLayout pattern does not play well with this optimization: see webkit.org/b/276253
+-            if (newChild->containingBlock() == &parent && !is<RenderVideo>(*newChild))
+-                parent.setOutOfFlowChildNeedsStaticPositionLayout();
+-            else
++            if (newChild->containingBlock() == &parent) {
++#if ENABLE(VIDEO)
++                if (!is<RenderVideo>(*newChild))
++#endif
++                    parent.setOutOfFlowChildNeedsStaticPositionLayout();
++            } else
+                 parent.setChildNeedsLayout();
+         } else
+             parent.setChildNeedsLayout();
+diff --git a/Source/WebCore/testing/Internals.cpp b/Source/WebCore/testing/Internals.cpp
+index a4308c8f..695a64ce 100644
+--- a/Source/WebCore/testing/Internals.cpp
++++ b/Source/WebCore/testing/Internals.cpp
+@@ -7550,10 +7550,12 @@ const String& Internals::defaultSpatialTrackingLabel() const
+     return nullString();
+ }
+ 
++#if ENABLE(VIDEO)
+ bool Internals::isEffectivelyMuted(const HTMLMediaElement& element)
+ {
+     return element.effectiveMuted();
+ }
++#endif
+ 
+ std::optional<RenderingMode> Internals::getEffectiveRenderingModeOfNewlyCreatedAcceleratedImageBuffer()
+ {
+diff --git a/Source/WebCore/testing/Internals.h b/Source/WebCore/testing/Internals.h
+index 284c0844..7d70386d 100644
+--- a/Source/WebCore/testing/Internals.h
++++ b/Source/WebCore/testing/Internals.h
+@@ -1481,7 +1481,9 @@ public:
+ 
+     const String& defaultSpatialTrackingLabel() const;
+ 
++#if ENABLE(VIDEO)
+     bool isEffectivelyMuted(const HTMLMediaElement&);
++#endif
+ 
+     using RenderingMode = WebCore::RenderingMode;
+     std::optional<RenderingMode> getEffectiveRenderingModeOfNewlyCreatedAcceleratedImageBuffer();
+diff --git a/Source/WebCore/testing/Internals.idl b/Source/WebCore/testing/Internals.idl
+index b28007dd..e6ecd9e1 100644
+--- a/Source/WebCore/testing/Internals.idl
++++ b/Source/WebCore/testing/Internals.idl
+@@ -1395,7 +1395,7 @@ enum RenderingMode {
+ 
+     readonly attribute DOMString defaultSpatialTrackingLabel;
+ 
+-    boolean isEffectivelyMuted(HTMLMediaElement element);
++    [Conditional=VIDEO] boolean isEffectivelyMuted(HTMLMediaElement element);
+ 
+     RenderingMode? getEffectiveRenderingModeOfNewlyCreatedAcceleratedImageBuffer();
+     Promise<ImageBufferResourceLimits> getImageBufferResourceLimits();
+diff --git a/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp b/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp
+index 9e7c7ce9..af9fcd03 100644
+--- a/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp
++++ b/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp
+@@ -425,8 +425,10 @@ void GPUConnectionToWebProcess::didClose(IPC::Connection& connection)
+     RemoteLegacyCDMFactoryProxy& legacyCdmFactoryProxy();
+ #endif
+ 
++#if ENABLE(VIDEO)
+     if (RefPtr remoteMediaResourceManager = m_remoteMediaResourceManager)
+         remoteMediaResourceManager->stopListeningForIPC();
++#endif
+ 
+     Ref gpuProcess = this->gpuProcess();
+     gpuProcess->connectionToWebProcessClosed(connection);
+diff --git a/Source/WebKit/WebProcess/GPU/media/gstreamer/VideoLayerRemoteGStreamer.cpp b/Source/WebKit/WebProcess/GPU/media/gstreamer/VideoLayerRemoteGStreamer.cpp
+index 4a553472..8baa1f7c 100644
+--- a/Source/WebKit/WebProcess/GPU/media/gstreamer/VideoLayerRemoteGStreamer.cpp
++++ b/Source/WebKit/WebProcess/GPU/media/gstreamer/VideoLayerRemoteGStreamer.cpp
+@@ -26,7 +26,7 @@
+ #include "config.h"
+ #include "VideoLayerRemote.h"
+ 
+-#if ENABLE(GPU_PROCESS)
++#if ENABLE(GPU_PROCESS) && ENABLE(VIDEO)
+ 
+ #include <WebCore/NotImplemented.h>
+ #include <WebCore/PlatformLayer.h>
+-- 
+2.34.1
+

--- a/recipes-browser/wpewebkit/wpewebkit/0002-Fix-WebKitSettings-build-for-ENABLE-VIDEO-https-bugs.patch
+++ b/recipes-browser/wpewebkit/wpewebkit/0002-Fix-WebKitSettings-build-for-ENABLE-VIDEO-https-bugs.patch
@@ -1,0 +1,33 @@
+From ee5736a2f1886c2fa1623f27f7ab8aee75c6c64e Mon Sep 17 00:00:00 2001
+From: Olivier Blin <olivier.blin@softathome.com>
+Date: Mon, 14 Oct 2024 06:24:30 -0700
+Subject: Fix WebKitSettings build for !ENABLE(VIDEO)
+ https://bugs.webkit.org/show_bug.cgi?id=281424
+
+Reviewed by Adrian Perez de Castro.
+
+Since 278688@main, WebKitSettings uses GUniquePtr for config file parsing.
+The <wtf/glib/GUniquePtr.h> header should be explicitly included.
+
+* Source/WebKit/UIProcess/API/glib/WebKitSettings.cpp:
+
+Canonical link: https://commits.webkit.org/285120@main
+---
+ Source/WebKit/UIProcess/API/glib/WebKitSettings.cpp | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/Source/WebKit/UIProcess/API/glib/WebKitSettings.cpp b/Source/WebKit/UIProcess/API/glib/WebKitSettings.cpp
+index a7980c6d..9519ca83 100644
+--- a/Source/WebKit/UIProcess/API/glib/WebKitSettings.cpp
++++ b/Source/WebKit/UIProcess/API/glib/WebKitSettings.cpp
+@@ -43,6 +43,7 @@
+ #include <cmath>
+ #include <glib/gi18n-lib.h>
+ #include <pal/text/TextEncodingRegistry.h>
++#include <wtf/glib/GUniquePtr.h>
+ #include <wtf/glib/WTFGType.h>
+ #include <wtf/text/CString.h>
+ 
+-- 
+2.34.1
+

--- a/recipes-browser/wpewebkit/wpewebkit/0003-Build-broken-with-ENABLE_WEB_AUDIO-OFF-https-bugs.we.patch
+++ b/recipes-browser/wpewebkit/wpewebkit/0003-Build-broken-with-ENABLE_WEB_AUDIO-OFF-https-bugs.we.patch
@@ -1,0 +1,38 @@
+From b674c3063ff783903d59c55ace17ff603848e961 Mon Sep 17 00:00:00 2001
+From: Olivier Blin <olivier.blin@softathome.com>
+Date: Thu, 10 Oct 2024 08:42:52 -0700
+Subject: Build broken with ENABLE_WEB_AUDIO=OFF
+ https://bugs.webkit.org/show_bug.cgi?id=281159
+
+Reviewed by Miguel Gomez.
+
+Since 280453@main, default values from UnifiedWebPreferences.yaml are used.
+Do not try to use WebAudioEnabled when undefined.
+
+* Source/WebKit/UIProcess/API/glib/WebKitSettings.cpp:
+(webkit_settings_class_init):
+
+Canonical link: https://commits.webkit.org/284970@main
+---
+ Source/WebKit/UIProcess/API/glib/WebKitSettings.cpp | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/Source/WebKit/UIProcess/API/glib/WebKitSettings.cpp b/Source/WebKit/UIProcess/API/glib/WebKitSettings.cpp
+index 9519ca83..0d67591e 100644
+--- a/Source/WebKit/UIProcess/API/glib/WebKitSettings.cpp
++++ b/Source/WebKit/UIProcess/API/glib/WebKitSettings.cpp
+@@ -1102,7 +1102,11 @@ static void webkit_settings_class_init(WebKitSettingsClass* klass)
+             "enable-webaudio",
+             _("Enable WebAudio"),
+             _("Whether WebAudio content should be handled"),
++#if ENABLE(WEB_AUDIO)
+             FEATURE_DEFAULT(WebAudioEnabled),
++#else
++            FALSE,
++#endif
+             readWriteConstructParamFlags);
+ 
+     /**
+-- 
+2.34.1
+

--- a/recipes-browser/wpewebkit/wpewebkit/0004-REGRESSION-277190-main-GTK-WPE-FELightingNeonParalle.patch
+++ b/recipes-browser/wpewebkit/wpewebkit/0004-REGRESSION-277190-main-GTK-WPE-FELightingNeonParalle.patch
@@ -1,0 +1,39 @@
+From 8ea155f88627cc9ccc8769770358def437885d59 Mon Sep 17 00:00:00 2001
+From: Adrian Perez de Castro <aperez@igalia.com>
+Date: Wed, 16 Oct 2024 07:35:37 -0700
+Subject: REGRESSION(277190@main): [GTK][WPE] FELightingNeonParallelApplier.cpp
+ build failed for cortexa8hf-neon
+ https://bugs.webkit.org/show_bug.cgi?id=276938
+
+Reviewed by Michael Catanzaro.
+
+PixelBuffer::bytes() returns a std::span after 277190@main, so do
+one more hoop through std::span::data() to get access to the raw
+pixel data pointer.
+
+* Source/WebCore/platform/graphics/cpu/arm/filters/FELightingNeonParallelApplier.cpp:
+(WebCore::FELightingNeonParallelApplier::applyPlatformParallel const):
+
+Canonical link: https://commits.webkit.org/285263@main
+---
+ .../graphics/cpu/arm/filters/FELightingNeonParallelApplier.cpp | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/Source/WebCore/platform/graphics/cpu/arm/filters/FELightingNeonParallelApplier.cpp b/Source/WebCore/platform/graphics/cpu/arm/filters/FELightingNeonParallelApplier.cpp
+index dccc003d..9152b693 100644
+--- a/Source/WebCore/platform/graphics/cpu/arm/filters/FELightingNeonParallelApplier.cpp
++++ b/Source/WebCore/platform/graphics/cpu/arm/filters/FELightingNeonParallelApplier.cpp
+@@ -520,8 +520,9 @@ void FELightingNeonParallelApplier::applyPlatformWorker(ApplyParameters* paramet
+ void FELightingNeonParallelApplier::applyPlatformParallel(const LightingData& data, const LightSource::PaintingData& paintingData) const
+ {
+     alignas(16) FloatArguments floatArguments;
++    auto bytes = data.pixels->bytes();
+     ApplyParameters neonData = {
+-        data.pixels->bytes(),
++        bytes.data(),
+         1,
+         data.width - 2,
+         data.height - 2,
+-- 
+2.34.1
+

--- a/recipes-browser/wpewebkit/wpewebkit_2.46.1.bb
+++ b/recipes-browser/wpewebkit/wpewebkit_2.46.1.bb
@@ -8,6 +8,7 @@ SRC_URI = "https://wpewebkit.org/releases/${BPN}-${PV}.tar.xz;name=tarball \
            file://0001-Build-fixes-for-ENABLE-VIDEO-https-bugs.webkit.org-s.patch \
            file://0002-Fix-WebKitSettings-build-for-ENABLE-VIDEO-https-bugs.patch \
            file://0003-Build-broken-with-ENABLE_WEB_AUDIO-OFF-https-bugs.we.patch \
+           file://0004-REGRESSION-277190-main-GTK-WPE-FELightingNeonParalle.patch \
           "
 
 SRC_URI[tarball.sha256sum] = "1e0aaf870f36001c42b1ce5a2027b4101bed878746e437cc6d6fed0693afe9ad"

--- a/recipes-browser/wpewebkit/wpewebkit_2.46.1.bb
+++ b/recipes-browser/wpewebkit/wpewebkit_2.46.1.bb
@@ -5,6 +5,9 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
 SRC_URI = "https://wpewebkit.org/releases/${BPN}-${PV}.tar.xz;name=tarball \
            file://0001-JSC-Fix-build-failure-on-musl-Add-fallback-for-round.patch \
+           file://0001-Build-fixes-for-ENABLE-VIDEO-https-bugs.webkit.org-s.patch \
+           file://0002-Fix-WebKitSettings-build-for-ENABLE-VIDEO-https-bugs.patch \
+           file://0003-Build-broken-with-ENABLE_WEB_AUDIO-OFF-https-bugs.we.patch \
           "
 
 SRC_URI[tarball.sha256sum] = "1e0aaf870f36001c42b1ce5a2027b4101bed878746e437cc6d6fed0693afe9ad"


### PR DESCRIPTION
- Applied patch to fix build issues when ENABLE(VIDEO) is disabled (https://bugs.webkit.org/show_bug.cgi?id=281253).
    
- Added a patch to fix WebKitSettings build for !ENABLE(VIDEO (https://bugs.webkit.org/show_bug.cgi?id=281424).
    
- Fixed a build issue when ENABLE_WEB_AUDIO=OFF by avoiding the use of WebAudioEnabled when the feature is not defined (https://bugs.webkit.org/show_bug.cgi?id=281159).
    
- Addressed a regression in FELightingNeonParallelApplier.cpp build for cortexa8hf-neon by adjusting pixel data pointer handling after upstream changes (https://bugs.webkit.org/show_bug.cgi?id=276938).
    

This PR is motivated in origin by these comments in PR #509:

* https://github.com/Igalia/meta-webkit/pull/509#issuecomment-2413374230
* https://github.com/Igalia/meta-webkit/pull/509#issuecomment-2415324665