### PR TITLE
Fix the layer avoid errors when build against Styhead Yocto release

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -17,4 +17,4 @@ BBFILE_PRIORITY_webkit = "7"
 BB_DANGLINGAPPENDS_WARNONLY = "true"
 
 # Support from the current actively maintained LTS Yocto release
-LAYERSERIES_COMPAT_webkit = "kirkstone langdale mickledore nanbield scarthgap"
+LAYERSERIES_COMPAT_webkit = "styhead kirkstone langdale mickledore nanbield scarthgap"

--- a/recipes-extended/highway/files/pr_1589.patch
+++ b/recipes-extended/highway/files/pr_1589.patch
@@ -33,7 +33,7 @@ See the documentation from GCC for the `Inlining rules` in the links from above.
 
 Issues related: #1570 and #1460.
 
-Upstream-Status: Accepted [https://github.com/google/highway/pull/1589]
+Upstream-Status: Backport [https://github.com/google/highway/pull/1589]
 ---
  hwy/ops/set_macros-inl.h | 4 ----
  1 file changed, 4 deletions(-)


### PR DESCRIPTION
This includes: 
highway: Fix the upstream status in pr_1589.patch
conf/layer: Add compatible Styhead Yocto release