### PR TITLE
Add Support for Styhead Release 

### DIFF
--- a/.github/manifest/manifest-styhead.xml
+++ b/.github/manifest/manifest-styhead.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<manifest>
+  <default sync-j="2"/>
+
+  <remote fetch="https://git.openembedded.org/" name="oe"/>
+  <remote fetch="https://git.yoctoproject.org/git/" name="yocto"/>
+  <remote fetch="https://github.com" name="github"/>
+  <remote fetch="https://github.com/Igalia" name="igalia"/>
+  <remote fetch="https://gitlab.com" name="gitlab"/>
+  <remote fetch="http://code.qt.io/yocto" name="qt"/>
+
+  <project remote="oe" revision="styhead" name="meta-openembedded" path="sources/meta-openembedded"/>
+
+  <project remote="yocto" revision="styhead" name="poky" path="sources/poky"/>
+  <project remote="yocto" revision="master" name="meta-raspberrypi" path="sources/meta-raspberrypi"/>
+
+  <project remote="igalia" revision="main" name="meta-webkit.git" path="sources/meta-webkit"/>
+</manifest>

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -84,3 +84,22 @@ jobs:
           repo_release: 'scarthgap'
     needs: scarthgap-repo
 
+  styhead-repo:
+    runs-on: self-hosted
+    if: "!contains(github.event.head_commit.message, 'ci skip')"
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/bitbake-repo
+        with:
+          repo_release: 'styhead'
+
+  styhead-raspberrypi3-mesa-weston-wpe-2-46:
+    runs-on: self-hosted
+    if: "!contains(github.event.head_commit.message, 'ci skip')"
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/bitbake-build
+        with:
+          bitbake_source: 'raspberrypi3-mesa-wpe-2-46 raspberrypi3-mesa poky layers.raspberrypi.webkit conf_v4.wpe-2_46'
+          repo_release: 'styhead'
+    needs: styhead-repo

--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -17,4 +17,4 @@ BBFILE_PRIORITY_webkit = "7"
 BB_DANGLINGAPPENDS_WARNONLY = "true"
 
 # Support from the current actively maintained LTS Yocto release
-LAYERSERIES_COMPAT_webkit = "kirkstone langdale mickledore nanbield scarthgap"
+LAYERSERIES_COMPAT_webkit = "kirkstone langdale mickledore nanbield scarthgap styhead"

--- a/recipes-extended/highway/files/pr_1589.patch
+++ b/recipes-extended/highway/files/pr_1589.patch
@@ -33,7 +33,7 @@ See the documentation from GCC for the `Inlining rules` in the links from above.
 
 Issues related: #1570 and #1460.
 
-Upstream-Status: Accepted [https://github.com/google/highway/pull/1589]
+Upstream-Status: Backport [https://github.com/google/highway/pull/1589]
 ---
  hwy/ops/set_macros-inl.h | 4 ----
  1 file changed, 4 deletions(-)


### PR DESCRIPTION
Add compatible Styhead Yocto release. These changes introduce support for the a `manifest-styhead.xml` in the `.github/manifest/` directory and update the GitHub Actions workflow to include build steps for the Styhead release.