### PR TITLE
wpewebkit: Implement synthesizeCompositionKeyPress() for WPE Platform

### DIFF
--- a/recipes-browser/wpewebkit/wpewebkit/0005-WPEPlatform-Input-methods-do-not-work.patch
+++ b/recipes-browser/wpewebkit/wpewebkit/0005-WPEPlatform-Input-methods-do-not-work.patch
@@ -1,0 +1,74 @@
+From 5de7f3a82abc68a628da1b54c2981f565fd483d4 Mon Sep 17 00:00:00 2001
+From: UndeadLeech <contact@christianduerr.com>
+Date: Tue, 24 Sep 2024 06:05:06 -0700
+Subject: [WPEPlatform] Input methods do not work
+ https://bugs.webkit.org/show_bug.cgi?id=279930
+
+Reviewed by Carlos Garcia Campos.
+
+Implement ViewPlatform::synthesizeCompositionKeyPress(), which was
+missing implementation for WPE.
+
+* Source/WebKit/Shared/NativeWebKeyboardEvent.h:
+* Source/WebKit/Shared/wpe/NativeWebKeyboardEventWPE.cpp:
+(WebKit::NativeWebKeyboardEvent::NativeWebKeyboardEvent): Add helper
+constructor, needed by ::synthesizeCompositionKeyPress().
+* Source/WebKit/UIProcess/API/wpe/WPEWebViewPlatform.cpp:
+(WKWPE::ViewPlatform::synthesizeCompositionKeyPress): Implement.
+
+Canonical link: https://commits.webkit.org/284155@main
+---
+ Source/WebKit/Shared/NativeWebKeyboardEvent.h          | 1 +
+ Source/WebKit/Shared/wpe/NativeWebKeyboardEventWPE.cpp | 5 +++++
+ Source/WebKit/UIProcess/API/wpe/WPEWebViewPlatform.cpp | 4 ++--
+ 3 files changed, 8 insertions(+), 2 deletions(-)
+
+Upstream-Status: Backport [https://commits.webkit.org/284155@main]
+
+diff --git a/Source/WebKit/Shared/NativeWebKeyboardEvent.h b/Source/WebKit/Shared/NativeWebKeyboardEvent.h
+index 17cb4210..c72c9733 100644
+--- a/Source/WebKit/Shared/NativeWebKeyboardEvent.h
++++ b/Source/WebKit/Shared/NativeWebKeyboardEvent.h
+@@ -83,6 +83,7 @@ public:
+     NativeWebKeyboardEvent(struct wpe_input_keyboard_event*, const String&, bool isAutoRepeat, HandledByInputMethod, std::optional<Vector<WebCore::CompositionUnderline>>&&, std::optional<EditingRange>&&);
+ #if PLATFORM(WPE) && ENABLE(WPE_PLATFORM)
+     NativeWebKeyboardEvent(WPEEvent*, const String&, bool isAutoRepeat);
++    NativeWebKeyboardEvent(const String&, std::optional<Vector<WebCore::CompositionUnderline>>&&, std::optional<EditingRange>&&);
+ #endif
+ #elif PLATFORM(WIN)
+     NativeWebKeyboardEvent(HWND, UINT message, WPARAM, LPARAM, Vector<MSG>&& pendingCharEvents);
+diff --git a/Source/WebKit/Shared/wpe/NativeWebKeyboardEventWPE.cpp b/Source/WebKit/Shared/wpe/NativeWebKeyboardEventWPE.cpp
+index e6cc8715..34d56bca 100644
+--- a/Source/WebKit/Shared/wpe/NativeWebKeyboardEventWPE.cpp
++++ b/Source/WebKit/Shared/wpe/NativeWebKeyboardEventWPE.cpp
+@@ -37,6 +37,11 @@ NativeWebKeyboardEvent::NativeWebKeyboardEvent(WPEEvent* event, const String& te
+ {
+ }
+ 
++NativeWebKeyboardEvent::NativeWebKeyboardEvent(const String& text, std::optional<Vector<WebCore::CompositionUnderline>>&& preeditUnderlines, std::optional<EditingRange>&& preeditSelectionRange)
++    : WebKeyboardEvent(WebEvent(WebEventType::KeyDown, { }, WallTime::now()), text, "Unidentified"_s, "Unidentified"_s, "U+0000"_s, 0, 0, true, WTFMove(preeditUnderlines), WTFMove(preeditSelectionRange), false, false)
++{
++}
++
+ } // namespace WebKit
+ 
+ #endif // ENABLE(WPE_PLATFORM)
+diff --git a/Source/WebKit/UIProcess/API/wpe/WPEWebViewPlatform.cpp b/Source/WebKit/UIProcess/API/wpe/WPEWebViewPlatform.cpp
+index a1d1aeb7..d69b3580 100644
+--- a/Source/WebKit/UIProcess/API/wpe/WPEWebViewPlatform.cpp
++++ b/Source/WebKit/UIProcess/API/wpe/WPEWebViewPlatform.cpp
+@@ -437,9 +437,9 @@ void ViewPlatform::handleGesture(WPEEvent* event)
+     }
+ }
+ 
+-void ViewPlatform::synthesizeCompositionKeyPress(const String&, std::optional<Vector<WebCore::CompositionUnderline>>&&, std::optional<EditingRange>&&)
++void ViewPlatform::synthesizeCompositionKeyPress(const String& text, std::optional<Vector<WebCore::CompositionUnderline>>&& underlines, std::optional<EditingRange>&& selectionRange)
+ {
+-    // FIXME: implement.
++    page().handleKeyboardEvent(WebKit::NativeWebKeyboardEvent(text, WTFMove(underlines), WTFMove(selectionRange)));
+ }
+ 
+ void ViewPlatform::setCursor(const WebCore::Cursor& cursor)
+-- 
+2.34.1
+

--- a/recipes-browser/wpewebkit/wpewebkit_2.46.2.bb
+++ b/recipes-browser/wpewebkit/wpewebkit_2.46.2.bb
@@ -6,6 +6,7 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 SRC_URI = "https://wpewebkit.org/releases/${BPN}-${PV}.tar.xz;name=tarball \
            file://0003-WPE-Platform-fix-wpe_toplevel_qtquick-has-not-been-d.patch \
            file://0004-WPE-Platform-fix-wpe_view_resize-was-not-declared-is.patch \
+           file://0005-WPEPlatform-Input-methods-do-not-work.patch \
           "
 
 SRC_URI[tarball.sha256sum] = "1b0ee5a6c8bfdc2f8d8aaa8be143d87e33a47117591176e41555252432cb13b6"


### PR DESCRIPTION
Added a new patch `0005-WPEPlatform-Input-methods-do-not-work.patch` to address the missing implementation of `synthesizeCompositionKeyPress()` in WPE Platform.

This patch resolves input method issues described in [Bug 279930](https://bugs.webkit.org/show_bug.cgi?id=279930).

Upstream-Status: Backport [https://commits.webkit.org/284155@main]