### PR TITLE
layer.conf: add LAYERDEPENDS

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -13,6 +13,11 @@ BBFILE_COLLECTIONS += "webkit"
 BBFILE_PATTERN_webkit := "^${LAYERDIR}/"
 BBFILE_PRIORITY_webkit = "7"
 
+LAYERDEPENDS_webkit = "\
+    core \
+    openembedded-layer \
+"
+
 # do not error out on bbappends for missing recipes
 BB_DANGLINGAPPENDS_WARNONLY = "true"
 


### PR DESCRIPTION
depend on core first of all.
In addtion add a depends on openembedded-layer
as wpewebkit configures a dependency on libbacktrace which is located in meta-oe aka openembedded-layer

Fixes errors like
Missing or unbuildable dependency chain was:
['meta-world-pkgdata', 'cog', 'wpewebkit', 'libbacktrace']