### PR TITLE
layer: move meta-webserver parts to dynamic layer

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -22,3 +22,4 @@ LAYERDEPENDS_webkit = "\
 
 # Support from the current actively maintained LTS Yocto release
 LAYERSERIES_COMPAT_webkit = "kirkstone langdale mickledore nanbield scarthgap styhead walnascar"
+LAYERRECOMMENDS_webkit = " webserver"

--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -7,6 +7,8 @@ BBFILES += "${LAYERDIR}/recipes-*/*/*.bb ${LAYERDIR}/recipes-*/*/*.bbappend"
 BBFILES_DYNAMIC += " \
     qt5-layer:${LAYERDIR}/dynamic-layers/qt5-layer/*/*/*.bb \
     qt5-layer:${LAYERDIR}/dynamic-layers/qt5-layer/*/*/*.bbappend \
+    webserver:${LAYERDIR}/dynamic-layers/webserver/*/*/*.bb \
+    webserver:${LAYERDIR}/dynamic-layers/webserver/*/*/*.bbappend \
     "
 
 BBFILE_COLLECTIONS += "webkit"

--- a/dynamic-layers/webserver/recipes-browser/packagegroups/packagegroup-wpewebkit-depends.bbappend
+++ b/dynamic-layers/webserver/recipes-browser/packagegroups/packagegroup-wpewebkit-depends.bbappend
@@ -1,0 +1,4 @@
+RDEPENDS:packagegroup-wpewebkit-depends-tests:append = " \
+    apache2 \
+    apache2-scripts \
+"

--- a/dynamic-layers/webserver/recipes-core/images/webkit-dev-ci-tools.bbappend
+++ b/dynamic-layers/webserver/recipes-core/images/webkit-dev-ci-tools.bbappend
@@ -1,0 +1,4 @@
+IMAGE_INSTALL:append = " \
+    apache2 \
+    apache2-scripts \
+"

--- a/recipes-browser/images/webkit-dev-ci-tools.bb
+++ b/recipes-browser/images/webkit-dev-ci-tools.bb
@@ -51,8 +51,6 @@ IMAGE_INSTALL:append = " \
     alsa-utils-aplay \
     alsa-utils-midi \
     alsa-utils-speakertest \
-    apache2 \
-    apache2-scripts \
     bridge-utils \
     cmake \
     curl \

--- a/recipes-browser/packagegroups/packagegroup-wpewebkit-depends.bb
+++ b/recipes-browser/packagegroups/packagegroup-wpewebkit-depends.bb
@@ -259,8 +259,6 @@ RDEPENDS:packagegroup-wpewebkit-depends-tests = " \
     git \
     subversion \
     bzip2 \
-    apache2 \
-    apache2-scripts \
     curl \
     gdb \
     php \


### PR DESCRIPTION
as apache2 and apache2-scripts are served out of meta-webserver, it is better to move them to a dynamic layer setup, then making the layer mandatory, when only a few users are affected by this