### PR TITLE
[backport][scarthgap] webkitgtk,wpewebkit: Bump to version 2.46.6

### DIFF
--- a/recipes-browser/webkitgtk/webkitgtk_2.46.6.bb
+++ b/recipes-browser/webkitgtk/webkitgtk_2.46.6.bb
@@ -32,7 +32,7 @@ SRC_URI = "https://www.webkitgtk.org/releases/webkitgtk-${PV}.tar.xz;name=tarbal
            file://fix-bmalloc-armhf.patch \
            "
 
-SRC_URI[tarball.sha256sum] = "bad4020bb0cfb3e740df3082c2d9cbf67cf4095596588a56aecdde6702137805"
+SRC_URI[tarball.sha256sum] = "f2b31de693220ba9bab76ce6ddfe5b0bfab2515cb2b0a70f3c54d4050766c32b"
 
 RRECOMMENDS:${PN} = "${PN}-bin \
                      ca-certificates \

--- a/recipes-browser/wpewebkit/wpewebkit_2.46.6.bb
+++ b/recipes-browser/wpewebkit/wpewebkit_2.46.6.bb
@@ -9,11 +9,11 @@ SRC_URI = "https://wpewebkit.org/releases/${BPN}-${PV}.tar.xz;name=tarball \
            file://0005-WPEPlatform-Input-methods-do-not-work.patch \
            "
 
-SRC_URI[tarball.sha256sum] = "2efd4831efcf86e29546c028d6f17a7b775b61b6499ed62399a00da8f06ea456"
+SRC_URI[tarball.sha256sum] = "2f8f8447b9c7b0578f7d751ca27c682a2c180b5abb91542af52a96e8a24a6262"
 
 SRCBRANCH:class-devupstream = "webkitglib/2.46"
 SRC_URI:class-devupstream = "git://github.com/WebKit/WebKit.git;protocol=https;branch=${SRCBRANCH}"
-SRCREV:class-devupstream = "43751e1d1959cf0735d155346a408fca80aecadb"
+SRCREV:class-devupstream = "2df8c2be6c990bc06d188b606595d9c8fe9e1870"
 
 # Experimental new WPE platform API
 PACKAGECONFIG[experimental-wpe-platform] = "-DENABLE_WPE_PLATFORM=ON,-DENABLE_WPE_PLATFORM=OFF,libinput wayland-native"


### PR DESCRIPTION
* Support building against ICU 76.1
* Fix lost initial audio samples played using WebAudio on 32-bit Raspberry Pi devices when using the OpenMAX GStreamer elements.
* Fix rendering on GPUs with maximum texture size smaller than 2000x2000 pixels by querying the maximum size supported at runtime.
* Fix a crash when enabling Skia CPU rendering.
* Fix several crashes and rendering issues.
