### PR TITLE
dav1d: Fix CVE-2024-1580

### DIFF
--- a/recipes-multimedia/dav1d/dav1d.inc
+++ b/recipes-multimedia/dav1d/dav1d.inc
@@ -4,7 +4,11 @@ BUGTRACKER = "https://code.videolan.org/videolan/dav1d/-/issues"
 
 DEPENDS = "nasm-native"
 
-SRC_URI = "https://code.videolan.org/videolan/${BPN}/-/archive/${PV}/${BPN}-${PV}.tar.gz"
+SRC_URI = " \
+    https://code.videolan.org/videolan/${BPN}/-/archive/${PV}/${BPN}-${PV}.tar.gz \
+    file://CVE-2024-1580.patch \
+    "
+    
 SRC_URI[sha256sum] = "097db6f370b88bf09fec62919c0d3af64e07d58210c665ec461d63f4ec79f6a2"
 
 LICENSE = "BSD-2-Clause"

--- a/recipes-multimedia/dav1d/dav1d/CVE-2024-1580.patch
+++ b/recipes-multimedia/dav1d/dav1d/CVE-2024-1580.patch
@@ -1,0 +1,66 @@
+From 8a9dbada543f4241da70c00c353d1aa0e133b6a2 Mon Sep 17 00:00:00 2001
+From: Henrik Gramner <gramner@twoorioles.com>
+Date: Tue, 21 Nov 2023 20:47:50 +0100
+Subject: [PATCH] Fix tile_start_off calculations for extremely large frame
+ sizes
+
+The tile start offset, in pixels, can exceed the range of a signed int.
+
+CVE: CVE-2024-1580
+Upstream-Status: Backport [https://code.videolan.org/videolan/dav1d/-/commit/2b475307dc11be9a1c3cc4358102c76a7f386a51]
+---
+ src/decode.c   | 13 +++++++------
+ src/internal.h |  2 +-
+ 2 files changed, 8 insertions(+), 7 deletions(-)
+
+diff --git a/src/decode.c b/src/decode.c
+index d810ed2..f1aa6ce 100644
+--- a/src/decode.c
++++ b/src/decode.c
+@@ -2359,7 +2359,7 @@ static void setup_tile(Dav1dTileState *const ts,
+                        const Dav1dFrameContext *const f,
+                        const uint8_t *const data, const size_t sz,
+                        const int tile_row, const int tile_col,
+-                       const int tile_start_off)
++                       const unsigned tile_start_off)
+ {
+     const int col_sb_start = f->frame_hdr->tiling.col_start_sb[tile_col];
+     const int col_sb128_start = col_sb_start >> !f->seq_hdr->sb128;
+@@ -2758,15 +2758,16 @@ int dav1d_decode_frame(Dav1dFrameContext *const f) {
+     const uint8_t *const size_mul = ss_size_mul[f->cur.p.layout];
+     const int hbd = !!f->seq_hdr->hbd;
+     if (c->n_fc > 1) {
++        const unsigned sb_step4 = f->sb_step * 4;
+         int tile_idx = 0;
+         for (int tile_row = 0; tile_row < f->frame_hdr->tiling.rows; tile_row++) {
+-            int row_off = f->frame_hdr->tiling.row_start_sb[tile_row] *
+-                          f->sb_step * 4 * f->sb128w * 128;
+-            int b_diff = (f->frame_hdr->tiling.row_start_sb[tile_row + 1] -
+-                          f->frame_hdr->tiling.row_start_sb[tile_row]) * f->sb_step * 4;
++            const unsigned row_off = f->frame_hdr->tiling.row_start_sb[tile_row] *
++                                     sb_step4 * f->sb128w * 128;
++            const unsigned b_diff = (f->frame_hdr->tiling.row_start_sb[tile_row + 1] -
++                                     f->frame_hdr->tiling.row_start_sb[tile_row]) * sb_step4;
+             for (int tile_col = 0; tile_col < f->frame_hdr->tiling.cols; tile_col++) {
+                 f->frame_thread.tile_start_off[tile_idx++] = row_off + b_diff *
+-                    f->frame_hdr->tiling.col_start_sb[tile_col] * f->sb_step * 4;
++                    f->frame_hdr->tiling.col_start_sb[tile_col] * sb_step4;
+             }
+         }
+ 
+diff --git a/src/internal.h b/src/internal.h
+index fb84422..cdaaa47 100644
+--- a/src/internal.h
++++ b/src/internal.h
+@@ -233,7 +233,7 @@ struct Dav1dFrameContext {
+         coef *cf;
+         int pal_sz, pal_idx_sz, cf_sz;
+         // start offsets per tile
+-        int *tile_start_off;
++        unsigned *tile_start_off;
+     } frame_thread;
+ 
+     // loopfilter
+-- 
+2.34.1
+


### PR DESCRIPTION
Backports patch for CVE-2024-1580 which affects dav1d 0.9.1.