### PR TITLE
Update README with additional layer dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,12 @@ This layer depends on:
     URI: git://git.openembedded.org/openembedded-core
     branch: main
     revision: HEAD
+    layers: meta
 
     URI: git://git.openembedded.org/meta-openembedded
     branch: main
     revision: HEAD
+    layers: meta-multimedia, meta-oe, meta-python
 
 This layer optionally depends on:
 


### PR DESCRIPTION
* Added `layers` information for `openembedded-core` and `meta-openembedded` in the README.
* Specified `meta` for `openembedded-core` and `meta-multimedia, meta-oe, meta-python` for `meta-openembedded`.

Issue: https://github.com/Igalia/meta-webkit/issues/536