### PR TITLE
wpebackend-fdo: bump to 1.14.4 and wpewebkit: update to 2.46.7

### DIFF
--- a/recipes-browser/wpebackend-fdo/wpebackend-fdo_1.14.4.bb
+++ b/recipes-browser/wpebackend-fdo/wpebackend-fdo_1.14.4.bb
@@ -1,9 +1,9 @@
 require wpebackend-fdo.inc
 require conf/include/devupstream.inc
 
-SRC_URI[sha256sum] = "10121842595a850291db3e82f3db0b9984df079022d386ce42c2b8508159dc6c"
+SRC_URI[sha256sum] = "d0edbd8f1850f5eb179bfa675db79d91b6f9ee8c8f94694a449e3cd975763410"
 
 SRCBRANCH:class-devupstream ?= "wpebackend-fdo-1.14"
 SRC_URI:class-devupstream = "git://github.com/Igalia/WPEBackend-fdo.git;protocol=https;branch=${SRCBRANCH}"
-SRCREV:class-devupstream = "04ccf2ef1753e72345770fb0a60bf38c5a100de8"
+SRCREV:class-devupstream = "b61725fe2dd523e99dbc2b81b23b298043540727"
 

--- a/recipes-browser/wpewebkit/wpewebkit_2.46.7.bb
+++ b/recipes-browser/wpewebkit/wpewebkit_2.46.7.bb
@@ -9,7 +9,7 @@ SRC_URI = "https://wpewebkit.org/releases/${BPN}-${PV}.tar.xz;name=tarball \
            file://0005-WPEPlatform-Input-methods-do-not-work.patch \
            "
 
-SRC_URI[tarball.sha256sum] = "2f8f8447b9c7b0578f7d751ca27c682a2c180b5abb91542af52a96e8a24a6262"
+SRC_URI[tarball.sha256sum] = "cf3e47638595d86de96abdb94db69a836c8aa509fc063be714f52c5a24bb5cd5"
 
 SRCBRANCH:class-devupstream = "webkitglib/2.46"
 SRC_URI:class-devupstream = "git://github.com/WebKit/WebKit.git;protocol=https;branch=${SRCBRANCH}"


### PR DESCRIPTION
This PR brings two upstream version bumps and related fixes to scarthgap:

* **wpebackend-fdo:** bump to 1.14.4

  * fix build with GCC 15
  * update release notes URL to [https://wpewebkit.org/release/wpebackend-fdo-1.14.4.html](https://wpewebkit.org/release/wpebackend-fdo-1.14.4.html)

* **wpewebkit:** update to version 2.46.7

  * rename recipe from `wpewebkit_2.46.6.bb` to `wpewebkit_2.46.7.bb`
  * update tarball SHA256 checksum
  * fix build when `USE_GSTREAMER_GL` is disabled
  * address several crashes and rendering issues

Partial backport of https://github.com/Igalia/meta-webkit/pull/545