### PR TITLE
libwpe: Improve metadata for oelint compliance

### DIFF
--- a/recipes-browser/libwpe/libwpe.inc
+++ b/recipes-browser/libwpe/libwpe.inc
@@ -1,16 +1,20 @@
-SUMMARY = "General-purpose library specifically developed for the WPE-flavored port of WebKit."
+SUMMARY = "General-purpose library specifically developed for the WPEWebKit."
+DESCRIPTION = "libwpe is a general-purpose C library that provides \
+               platform-agnostic interfaces for integrating WPE WebKit with \
+               various backend implementations"
 HOMEPAGE = "https://github.com/WebPlatformForEmbedded/libwpe"
 BUGTRACKER = "https://github.com/WebPlatformForEmbedded/libwpe/issues"
 
-SRC_URI = "https://wpewebkit.org/releases/${BPN}-${PV}.tar.xz"
-
 LICENSE = "BSD-2-Clause"
 LIC_FILES_CHKSUM = "file://COPYING;md5=371a616eb4903c6cb79e9893a5f615cc"
+
 DEPENDS:append = " virtual/egl"
 
 PROVIDES += "virtual/libwpe"
 
-# Workaround build issue with RPi userland EGL libraries.
+SRC_URI = "https://wpewebkit.org/releases/${BPN}-${PV}.tar.xz"
+
+# nooelint: oelint.vars.specific - Workaround build issue with RPi userland EGL libraries.
 CFLAGS:append:rpi = " ${@bb.utils.contains('MACHINE_FEATURES', 'vc4graphics', '', '-D_GNU_SOURCE', d)}"
 
 inherit features_check pkgconfig meson


### PR DESCRIPTION
Update summary and description to align with oelint style expectations. Reorder `SRC_URI` to match recommended positioning and add a directive to silence false positive on RPi-specific CFLAGS override.

Maintenance-Type: unreviewed-change