### PR TITLE
libavif: fix CVE-2025-48174

### DIFF
--- a/recipes-multimedia/libavif/files/CVE-2025-48174.patch
+++ b/recipes-multimedia/libavif/files/CVE-2025-48174.patch
@@ -1,0 +1,59 @@
+From: DanisJiang <43723722+DanisJiang@users.noreply.github.com>
+Subject: Add integer overflow checks to makeRoom (CVE-2025-48174)
+Origin: backport, https://github.com/AOMediaCodec/libavif/commit/e5fdefe7d1776e6c4cf1703c163a8c053559902,
+ https://github.com/AOMediaCodec/libavif/commit/50a743062938a3828581d725facc9c2b92a1d109,
+ https://github.com/AOMediaCodec/libavif/commit/c9f1bea437f21cb78f9919c332922a3b0ba65e11
+Bug: https://github.com/AOMediaCodec/libavif/pull/2768
+Bug-Debian: https://bugs.debian.org/1105885
+Bug-Debian-Security: https://security-tracker.debian.org/tracker/CVE-2025-48174
+
+Instead of backporting requsites for the patches from
+https://github.com/AOMediaCodec/libavif/pull/2768 make the overflow check and
+abort() instead. Use abort() to be consistent with avifAlloc() in libavif
+v0.11.1 (in src/mem.c):
+
+	void * avifAlloc(size_t size)
+	{
+	    void * out = malloc(size);
+	    if (out == NULL) {
+		abort();
+	    }
+	    return out;
+	}
+
+Include <stdlib.h> for abort().
+
+Thanks: Wan-Teh Chang <wtc@google.com>
+
+Upstream-Status: Backport [https://github.com/AOMediaCodec/libavif/commit/e5fdefe7d1776e6c4cf1703c163a8c053559902 && https://github.com/AOMediaCodec/libavif/commit/50a743062938a3828581d725facc9c2b92a1d109 && https://github.com/AOMediaCodec/libavif/commit/c9f1bea437f21cb78f9919c332922a3b0ba65e11]
+CVE: CVE-2025-48174
+Signed-off-by: Hitendra Prajapati <hprajapati@mvista.com>
+---
+ src/stream.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/src/stream.c b/src/stream.c
+index a5935b4f..4a343676 100644
+--- a/src/stream.c
++++ b/src/stream.c
+@@ -6,6 +6,7 @@
+ #include <assert.h>
+ #include <inttypes.h>
+ #include <stdint.h>
++#include <stdlib.h>
+ #include <string.h>
+ 
+ // ---------------------------------------------------------------------------
+@@ -234,6 +235,9 @@ avifBool avifROStreamReadAndEnforceVersion(avifROStream * stream, uint8_t enforc
+ #define AVIF_STREAM_BUFFER_INCREMENT (1024 * 1024)
+ static void makeRoom(avifRWStream * stream, size_t size)
+ {
++    if (size > SIZE_MAX - stream->offset) {
++        abort();
++    }
+     size_t neededSize = stream->offset + size;
+     size_t newSize = stream->raw->size;
+     while (newSize < neededSize) {
+-- 
+2.49.0
+

--- a/recipes-multimedia/libavif/libavif.inc
+++ b/recipes-multimedia/libavif/libavif.inc
@@ -2,7 +2,9 @@ SUMMARY = "This library aims to be a friendly, portable C implementation of the 
 HOMEPAGE = "https://github.com/AOMediaCodec/libavif"
 BUGTRACKER = "https://github.com/AOMediaCodec/libavif/issues"
 
-SRC_URI = "git://github.com/AOMediaCodec/libavif.git;protocol=https;branch=main"
+SRC_URI = "git://github.com/AOMediaCodec/libavif.git;protocol=https;branch=main \
+	   file://CVE-2025-48174.patch \
+	  "
 SRCREV = "6ab53189045e7a6fe0bd93d14977b2a4f8efa5e9"
 
 S = "${WORKDIR}/git"


### PR DESCRIPTION
Upstream-Status: Backport from https://github.com/AOMediaCodec/libavif/commit/e5fdefe7d1776e6c4cf1703c163a8c053559902 && https://github.com/AOMediaCodec/libavif/commit/50a743062938a3828581d725facc9c2b92a1d109 && https://github.com/AOMediaCodec/libavif/commit/c9f1bea437f21cb78f9919c332922a3b0ba65e11