### PR TITLE
cog: Update to 0.18.5

### DIFF
--- a/recipes-browser/cog/cog_0.18.5.bb
+++ b/recipes-browser/cog/cog_0.18.5.bb
@@ -2,11 +2,11 @@ require cog.inc
 require cog-meson.inc
 require conf/include/devupstream.inc
 
-SRC_URI[sha256sum] = "31d7079db2eeed790899d2f1f824dd6a54bf30d072d196d737be572f105d99b1"
+SRC_URI[sha256sum] = "0ede9d09ab635ac519beec0543378e3fc51b56561a5fb7aa9c0cbca54c31b97c"
 
 SRCBRANCH:class-devupstream ?= "cog-0.18"
 SRC_URI:class-devupstream = "git://github.com/Igalia/cog.git;protocol=https;branch=${SRCBRANCH}"
-SRCREV:class-devupstream = "c4625676a21308e7c82175f1ce9a6c8849f22800"
+SRCREV:class-devupstream = "5d7c720e4f16360a0412a949a1a3f4209e81b9ec"
 
 RDEPENDS:${PN} += "wpewebkit (>= 2.42)"
 


### PR DESCRIPTION
This provides several bug fixes, including:

* meson: Make the libmanette support explicitly configurable.
* core: Avoid re-registration of URI scheme handlers.
* wl: Fix mouse button release events, always passing the button number.
* wl: Fix the key repeat timeout.
* wl: Handle mouse button modifiers.

Release notes: https://github.com/Igalia/cog/releases/tag/0.18.5