### PR TITLE
qt-wpe-simple-browser: WORKDIR -> UNPACKDIR transition

### DIFF
--- a/dynamic-layers/qt5-layer/recipes-qt/qt-wpe-simple-browser/qt-wpe-simple-browser_0.1.bb
+++ b/dynamic-layers/qt5-layer/recipes-qt/qt-wpe-simple-browser/qt-wpe-simple-browser_0.1.bb
@@ -11,8 +11,6 @@ SRC_URI = "file://CMakeLists.txt \
            file://qml.qrc \
 "
 
-S = "${WORKDIR}"
-
 inherit cmake cmake_qt5
 
 do_install() {


### PR DESCRIPTION
This adapts to the oe-core rework to enforce a separate directory for unpacking local sources (UNPACKDIR) instead of directly using WORKDIR.