### PR TITLE
Update WebKitGTK and WPE WebKit updates to 2.48.5

### DIFF
--- a/recipes-browser/webkitgtk/webkitgtk_2.48.5.bb
+++ b/recipes-browser/webkitgtk/webkitgtk_2.48.5.bb
@@ -40,7 +40,7 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
 SRC_URI = "https://www.webkitgtk.org/releases/webkitgtk-${PV}.tar.xz;name=tarball"
 
-SRC_URI[tarball.sha256sum] = "d4dc5970f0fc6a529ff7fd67bcbfab2bbb5e91be789b2e9279640b3217a782c3"
+SRC_URI[tarball.sha256sum] = "bb64ed9d1cfd58e8b5e89ccad71dd31adfed56336bad7695031ad0b668e1987c"
 
 RRECOMMENDS:${PN} = "${PN}-bin \
                      ca-certificates \

--- a/recipes-browser/wpewebkit/wpewebkit/0002-REGRESSION-2.48.5-WPE-GTK-Does-not-compile-on-ARMv7.patch
+++ b/recipes-browser/wpewebkit/wpewebkit/0002-REGRESSION-2.48.5-WPE-GTK-Does-not-compile-on-ARMv7.patch
@@ -1,0 +1,33 @@
+From 7999ecd5ee4ea3123f7e75634d2bc57f57ca7070 Mon Sep 17 00:00:00 2001
+From: Justin Michaud <jmichaud@igalia.com>
+Date: Wed, 6 Aug 2025 21:14:26 +0300
+Subject: REGRESSION(2.48.5): [WPE][GTK] Does not compile on ARMv7
+ https://bugs.webkit.org/show_bug.cgi?id=296921
+
+Unreviewed build fix.
+
+* Source/JavaScriptCore/llint/WebAssembly.asm: Replace addq with addp
+  for sp on armv7
+
+Canonical link: https://commits.webkit.org/290945.344@webkitglib/2.48
+---
+ Source/JavaScriptCore/llint/WebAssembly.asm | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+Upstream-Status: Backport [https://bugs.webkit.org/show_bug.cgi?id=296921]
+diff --git a/Source/JavaScriptCore/llint/WebAssembly.asm b/Source/JavaScriptCore/llint/WebAssembly.asm
+index 1ac3e2accf3c..bd9041404eb1 100644
+--- a/Source/JavaScriptCore/llint/WebAssembly.asm
++++ b/Source/JavaScriptCore/llint/WebAssembly.asm
+@@ -736,7 +736,7 @@ if JSVALUE64
+     storep memoryBase, Callee[cfr]
+ else
+     loadp [sp], ws0
+-    addq 2 * SlotSize, sp
++    addp 2 * SlotSize, sp
+     storep ws0, Callee[cfr]
+ end
+ 
+-- 
+2.43.0
+

--- a/recipes-browser/wpewebkit/wpewebkit_2.48.5.bb
+++ b/recipes-browser/wpewebkit/wpewebkit_2.48.5.bb
@@ -5,13 +5,14 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
 SRC_URI = "https://wpewebkit.org/releases/${BPN}-${PV}.tar.xz;name=tarball \
            file://0001-Enforce-surface-size-match-when-maximized-to-avoid-W.patch \
+           file://0002-REGRESSION-2.48.5-WPE-GTK-Does-not-compile-on-ARMv7.patch \
           "
 
-SRC_URI[tarball.sha256sum] = "78b94ec66af03cb01d304253bb1ca4e45ffdfdab4bf40342e592b7dbfc696e8f"
+SRC_URI[tarball.sha256sum] = "01f36010705adb14404c56baf033147f7927cc7c6badec81bb141266fcdd8d0b"
 
 SRCBRANCH:class-devupstream = "webkitglib/2.48"
 SRC_URI:class-devupstream = "git://github.com/WebKit/WebKit.git;protocol=https;branch=${SRCBRANCH}"
-SRCREV:class-devupstream = "b62d21a5e959a8f9199e7cb8dad6d4df8a097f51"
+SRCREV:class-devupstream = "8f7f470b41951ad4b90a633338aa57ddaa768c92"
 
 # Experimental new WPE platform API
 PACKAGECONFIG[experimental-wpe-platform] = "-DENABLE_WPE_PLATFORM=ON,-DENABLE_WPE_PLATFORM=OFF,libinput wayland-native"


### PR DESCRIPTION
**Description:**
This PR performs the following updates:

* **WebKitGTK:** Update from 2.48.3 to 2.48.5
* **WPEWebKit:** Update to 2.48.5
