### PR TITLE
webkitdevci: add sysprof-staticdev as build dependency

### DIFF
--- a/recipes-browser/images/webkit-dev-ci-tools.bb
+++ b/recipes-browser/images/webkit-dev-ci-tools.bb
@@ -83,7 +83,6 @@ IMAGE_INSTALL:append = " \
     pv \
     rsync \
     screen \
-    sysprof \
     smem \
     systemd-analyze \
     unifdef \

--- a/recipes-browser/packagegroups/packagegroup-wpewebkit-depends.bb
+++ b/recipes-browser/packagegroups/packagegroup-wpewebkit-depends.bb
@@ -132,6 +132,8 @@ RDEPENDS:packagegroup-wpewebkit-depends-core = "\
     icu \
     jpeg \
     sqlite3 \
+    sysprof \
+    sysprof-staticdev \
     zlib \
     libpng \
     libsoup \


### PR DESCRIPTION
When WPE is built with -DUSE_SYSTEM_SYSPROF_CAPTURE=ON it looks for a static library (.a) named sysprof-capture-4, but yocto by default ships static libraries in a -staticdev package that is not included by default on the sysroot.

So explicitly include the -staticdev package in this case