### PR TITLE
webkit-dev-ci-tools image: ship netdata but with systemd unit disabled

### DIFF
--- a/classes/systemd-auto-enable-policy.bbclass
+++ b/classes/systemd-auto-enable-policy.bbclass
@@ -1,0 +1,8 @@
+# Easily allow to disable specific systemd services at the distro level conf
+python __anonymous() {
+    if bb.utils.contains('DISTRO_FEATURES', 'systemd', True, False, d):
+        packages_to_disable = d.getVar('SYSTEMD_AUTOSTART_DISABLE') or ''
+        pn = d.getVar('PN')
+        if pn in packages_to_disable.split():
+            d.setVar('SYSTEMD_AUTO_ENABLE:%s' % pn, 'disable')
+}

--- a/conf/distro/webkitdevci.conf
+++ b/conf/distro/webkitdevci.conf
@@ -48,5 +48,11 @@ PACKAGECONFIG:append:pn-php = " apache2"
 # Disable mysql support as we don't need to build mysql/mariadb
 PACKAGECONFIG:remove:pn-php = "mysql"
 
+# Disable the following systemd services by default
+# - Netdata: is only needed on the RPi4 bots and is manually enabled there (via deploy-webkit-buildbot-ews).
+# - Apache2: the service is not needed for the tests, the layout test runner takes care of starting/stopping it.
+INHERIT += "systemd-auto-enable-policy"
+SYSTEMD_AUTOSTART_DISABLE = "netdata apache2"
+
 # Whitelist license from some deps.
 LICENSE_FLAGS_ACCEPTED:append = " commercial synaptics-killswitch"

--- a/dynamic-layers/webserver/recipes-core/images/webkit-dev-ci-tools.bbappend
+++ b/dynamic-layers/webserver/recipes-core/images/webkit-dev-ci-tools.bbappend
@@ -1,4 +1,5 @@
 IMAGE_INSTALL:append = " \
     apache2 \
     apache2-scripts \
+    netdata \
 "


### PR DESCRIPTION
On the WebKit image created via cross-toolchain-helper script we have been including netdata for a while in the local.conf files there because we use this to capture performance data from the RPi4 bots when those are running the tests.

However, this netdata service should not be started by default because it is only useful on the bots, but it is not useful for developers and it may cause CPU spikes if not configured properly.

When the bots are deployed we setup a specific configuration for netdata (to rely the data to a remote server) and we also take care of enabling the systemd unit there.

So this patch adds netdata into the image but configures it to be disabled by default. Meanwhile at it, disable also the apache2 service which is not needed (the service) for the tests (having the binary is enough).