### PR TITLE
webkitgtk,wpewebkit: Update to version 2.52.1

### DIFF
--- a/.github/manifest/manifest-whinlatter.xml
+++ b/.github/manifest/manifest-whinlatter.xml
@@ -9,10 +9,10 @@
   <remote fetch="https://gitlab.com" name="gitlab"/>
   <remote fetch="http://code.qt.io/yocto" name="qt"/>
 
-  <project remote="oe" revision="master" name="meta-openembedded" path="sources/meta-openembedded"/>
+  <project remote="oe" revision="whinlatter" name="meta-openembedded" path="sources/meta-openembedded"/>
 
   <project remote="yocto" revision="f4c37762b9df1bccccdbccc3d72e79d83e67e47a" name="poky" path="sources/poky"/>
-  <project remote="yocto" revision="master" name="meta-raspberrypi" path="sources/meta-raspberrypi"/>
+  <project remote="yocto" revision="whinlatter" name="meta-raspberrypi" path="sources/meta-raspberrypi"/>
 
   <project remote="igalia" revision="main" name="meta-webkit.git" path="sources/meta-webkit"/>
 </manifest>

--- a/recipes-browser/webkitgtk/webkitgtk_2.52.1.bb
+++ b/recipes-browser/webkitgtk/webkitgtk_2.52.1.bb
@@ -43,7 +43,7 @@ DEPENDS = "curl \
 "
 
 SRC_URI = "https://www.webkitgtk.org/releases/webkitgtk-${PV}.tar.xz;name=tarball;subdir=${BP};striplevel=1"
-SRC_URI[tarball.sha256sum] = "b31c55f18194ac83ba08c9b93bbeffef57a7ecff7f41c874d17a9e7853dca19f"
+SRC_URI[tarball.sha256sum] = "238e7d53205b14004add7eeb4293c94d6fbf7097b3efef7cee5519e5c121a904"
 
 inherit cmake lib_package pkgconfig perlnative python3native
 

--- a/recipes-browser/wpewebkit/wpewebkit_2.52.1.bb
+++ b/recipes-browser/wpewebkit/wpewebkit_2.52.1.bb
@@ -3,8 +3,8 @@ require conf/include/devupstream.inc
 
 SRC_URI = "https://wpewebkit.org/releases/${BPN}-${PV}.tar.xz;name=tarball"
 
-SRC_URI[tarball.sha256sum] = "3adbf9eebec9b7535febb75aca5afa1ea586eaf9b0cdfd3eb56de850fe39ff43"
+SRC_URI[tarball.sha256sum] = "eb776b26ac14e385b8cd00df04056daf3c1dd2443ecacc20428d8df8b0ae63bf"
 
 SRCBRANCH:class-devupstream = "webkitglib/2.52"
 SRC_URI:class-devupstream = "git://github.com/WebKit/WebKit.git;protocol=https;branch=${SRCBRANCH}"
-SRCREV:class-devupstream = "19a3c6b3a65aca2877630c45be9a8bfde110103e"
+SRCREV:class-devupstream = "a5dcc72eee888897b4623ae58c0f60d5e5c7e114"


### PR DESCRIPTION
* Update webkitgtk to the new 2.52.1 release from the stable 2.52 series.
* Update wpewebkit to the new 2.52.1 release from the stable 2.52 series.