### PR TITLE
webkitgtk,wpewebkit: Update to version 2.52.2

### DIFF
--- a/recipes-browser/webkitgtk/webkitgtk_2.52.2.bb
+++ b/recipes-browser/webkitgtk/webkitgtk_2.52.2.bb
@@ -43,7 +43,7 @@ DEPENDS = "curl \
 "
 
 SRC_URI = "https://www.webkitgtk.org/releases/webkitgtk-${PV}.tar.xz;name=tarball;subdir=${BP};striplevel=1"
-SRC_URI[tarball.sha256sum] = "238e7d53205b14004add7eeb4293c94d6fbf7097b3efef7cee5519e5c121a904"
+SRC_URI[tarball.sha256sum] = "05de2b44874ba2dada5755f898cfb53783c3173f91b46368fa2dccc584972abb"
 
 inherit cmake lib_package pkgconfig perlnative python3native
 

--- a/recipes-browser/wpewebkit/wpewebkit_2.52.2.bb
+++ b/recipes-browser/wpewebkit/wpewebkit_2.52.2.bb
@@ -3,8 +3,8 @@ require conf/include/devupstream.inc
 
 SRC_URI = "https://wpewebkit.org/releases/${BPN}-${PV}.tar.xz;name=tarball"
 
-SRC_URI[tarball.sha256sum] = "eb776b26ac14e385b8cd00df04056daf3c1dd2443ecacc20428d8df8b0ae63bf"
+SRC_URI[tarball.sha256sum] = "cef4407fd39ac5ad8c9309693eb3601bcec8fdfdcb9b9fbff4c725e67a2c8173"
 
 SRCBRANCH:class-devupstream = "webkitglib/2.52"
 SRC_URI:class-devupstream = "git://github.com/WebKit/WebKit.git;protocol=https;branch=${SRCBRANCH}"
-SRCREV:class-devupstream = "a5dcc72eee888897b4623ae58c0f60d5e5c7e114"
+SRCREV:class-devupstream = "cf21484ec86ceaecafcec42927ef2b4900058ced"


### PR DESCRIPTION
- Update webkitgtk to the new 2.52.2 release from the stable 2.52 series.
- Update wpewebkit to the new 2.52.2 release from the stable 2.52 series.