### PR TITLE
webkitgtk,wpewebkit: Update to version 2.52.4

### DIFF
--- a/recipes-browser/webkitgtk/webkitgtk_2.52.4.bb
+++ b/recipes-browser/webkitgtk/webkitgtk_2.52.4.bb
@@ -43,7 +43,7 @@ DEPENDS = "curl \
 "
 
 SRC_URI = "https://www.webkitgtk.org/releases/webkitgtk-${PV}.tar.xz;name=tarball;subdir=${BP};striplevel=1"
-SRC_URI[tarball.sha256sum] = "5b3e0d174e63dcc28848b1194e0e7448d5948c3c2427ecd931c2c5be5261aebb"
+SRC_URI[tarball.sha256sum] = "cf4076a1ca2a64788edca8c452d8ebb68d5e2965e588fe46a388a016513edce4"
 
 inherit cmake lib_package pkgconfig perlnative python3native
 

--- a/recipes-browser/wpewebkit/wpewebkit_2.52.4.bb
+++ b/recipes-browser/wpewebkit/wpewebkit_2.52.4.bb
@@ -3,8 +3,8 @@ require conf/include/devupstream.inc
 
 SRC_URI = "https://wpewebkit.org/releases/${BPN}-${PV}.tar.xz;name=tarball"
 
-SRC_URI[tarball.sha256sum] = "b51b1db1e6ee99d1771f4a358c128fde27a77984df20ee6cb59858e520662d0b"
+SRC_URI[tarball.sha256sum] = "01ca34cd7af880c038d35aa94482fee785a77db37b614c584475d7d43b3a2dc0"
 
 SRCBRANCH:class-devupstream = "webkitglib/2.52"
 SRC_URI:class-devupstream = "git://github.com/WebKit/WebKit.git;protocol=https;branch=${SRCBRANCH}"
-SRCREV:class-devupstream = "5b58d7028bf6200b044538a98fd0963c70837eae"
+SRCREV:class-devupstream = "eb3f22e0713f185bd676b49e88249555cf677a0a"


### PR DESCRIPTION
- Update webkitgtk to the new 2.52.4 release from the stable 2.52 series.
- Update wpewebkit to the new 2.52.4 release from the stable 2.52 series.