### PR TITLE
webkitgtk,wpewebkit: Update to version 2.52.5

### DIFF
--- a/recipes-browser/webkitgtk/webkitgtk_2.52.5.bb
+++ b/recipes-browser/webkitgtk/webkitgtk_2.52.5.bb
@@ -43,7 +43,7 @@ DEPENDS = "curl \
 "
 
 SRC_URI = "https://www.webkitgtk.org/releases/webkitgtk-${PV}.tar.xz;name=tarball;subdir=${BP};striplevel=1"
-SRC_URI[tarball.sha256sum] = "cf4076a1ca2a64788edca8c452d8ebb68d5e2965e588fe46a388a016513edce4"
+SRC_URI[tarball.sha256sum] = "8a531a9abd2215936e8a8a914c077b586c0228b31d652f205286a8ec90f3364b"
 
 inherit cmake lib_package pkgconfig perlnative python3native
 

--- a/recipes-browser/wpewebkit/wpewebkit_2.52.5.bb
+++ b/recipes-browser/wpewebkit/wpewebkit_2.52.5.bb
@@ -3,8 +3,8 @@ require conf/include/devupstream.inc
 
 SRC_URI = "https://wpewebkit.org/releases/${BPN}-${PV}.tar.xz;name=tarball"
 
-SRC_URI[tarball.sha256sum] = "01ca34cd7af880c038d35aa94482fee785a77db37b614c584475d7d43b3a2dc0"
+SRC_URI[tarball.sha256sum] = "bcfc6c91db7659dcf24f6ff79ad27ac1eae1bc61dca0dbfee154706926740b3b"
 
 SRCBRANCH:class-devupstream = "webkitglib/2.52"
 SRC_URI:class-devupstream = "git://github.com/WebKit/WebKit.git;protocol=https;branch=${SRCBRANCH}"
-SRCREV:class-devupstream = "eb3f22e0713f185bd676b49e88249555cf677a0a"
+SRCREV:class-devupstream = "9d11fa1a37e61a75d8167ee4bc1a8e7604aff408"


### PR DESCRIPTION
- Update webkitgtk to the new 2.52.5 release from the stable 2.52 series.
- Update wpewebkit to the new 2.52.5 release from the stable 2.52 series.