### PR TITLE
wpe-simple-launcher: Add recipe

### DIFF
--- a/recipes-browser/wpe-simple-launcher/wpe-simple-launcher/wpe-ctl
+++ b/recipes-browser/wpe-simple-launcher/wpe-simple-launcher/wpe-ctl
@@ -1,0 +1,9 @@
+#!/bin/sh
+CTL_FILE="/tmp/wpe-exported-wayland"
+
+if [ ! -p "$CTL_FILE" ]; then
+    echo "wpe-ctl: control FIFO not found: $CTL_FILE" >&2
+    exit 1
+fi
+
+printf '%s\n' "$*" >"$CTL_FILE"

--- a/recipes-browser/wpe-simple-launcher/wpe-simple-launcher/wpe-exported-wayland
+++ b/recipes-browser/wpe-simple-launcher/wpe-simple-launcher/wpe-exported-wayland
@@ -11,7 +11,7 @@ export GST_PLUGIN_FEATURE_RANK="avdec_av1:0"
 # mkdir -p /tmp/gst-out
 # chmod 777 /tmp/gst-out
 
-# Temporary file to store Wayland control data
+# FIFO path used for the wpe-simple-launcher --ctrl channel (see wpe-ctl)
 CTL_FILE="/tmp/wpe-exported-wayland"
 
 # Enable DMA-BUF video sink in WebKit for efficient rendering.

--- a/recipes-browser/wpe-simple-launcher/wpe-simple-launcher/wpe-exported-wayland
+++ b/recipes-browser/wpe-simple-launcher/wpe-simple-launcher/wpe-exported-wayland
@@ -1,0 +1,54 @@
+#!/bin/sh
+
+# Disable sandboxing for WebKit (dangerous, use with caution)
+# export WEBKIT_DISABLE_SANDBOX_THIS_IS_DANGEROUS=1
+
+# Lower rank of AV1 decoder to disable it
+export GST_PLUGIN_FEATURE_RANK="avdec_av1:0"
+
+# Set directory for GStreamer debug output
+# export GST_DEBUG_DUMP_DOT_DIR=/tmp/gst-out/
+# mkdir -p /tmp/gst-out
+# chmod 777 /tmp/gst-out
+
+# Temporary file to store Wayland control data
+CTL_FILE="/tmp/wpe-exported-wayland"
+
+# Enable DMA-BUF video sink in WebKit for efficient rendering.
+# WebKitDMABufVideoSink sink that is able to accept decode
+# dmabuf or raw data in a range of RGB-like or YUV formats.
+# Bug: https://bugs.webkit.org/show_bug.cgi?id=279819
+#
+# Apply workaround only if running on raspberrypi5
+if [ "$(hostname)" = "raspberrypi5" ]; then
+    export WEBKIT_GST_DMABUF_SINK_ENABLED=1
+fi
+
+# Regression in 2.48.X since
+#   [GStreamer] Add support for DMA-BUF to GL video sink
+#   https://bugs.webkit.org/show_bug.cgi?id=279672
+# XXX Reported in : https://bugs.webkit.org/show_bug.cgi?id=288464
+#
+# Apply regression workaround only if running on raspberrypi5
+if [ "$(hostname)" = "raspberrypi5" ]; then
+    export WEBKIT_GST_DISABLE_GL_SINK=1
+fi
+
+# Ensure Wayland and XDG runtime environment variables are propagated
+WESTON_PID="$(pidof -s weston-keyboard 2>/dev/null || true)"
+if [ -z "$WESTON_PID" ] || [ ! -r "/proc/$WESTON_PID/environ" ]; then
+    echo "wpe-exported-wayland: unable to read weston-keyboard environment" >&2
+    exit 1
+fi
+
+WAYLAND_DISPLAY="$(tr '\0' '\n' < "/proc/$WESTON_PID/environ" | grep -m1 '^WAYLAND_DISPLAY=')"
+XDG_RUNTIME_DIR="$(tr '\0' '\n' < "/proc/$WESTON_PID/environ" | grep -m1 '^XDG_RUNTIME_DIR=')"
+export "${WAYLAND_DISPLAY?}"
+export "${XDG_RUNTIME_DIR?}"
+
+# Check if the script is run as root and switch to the 'weston' user if needed
+if [ "$(id -u)" -eq 0 ]; then
+    su -s /bin/sh weston -c 'ctl="$1"; shift; exec /usr/bin/wpe-simple-launcher --ctrl "$ctl" "$@"' sh "$CTL_FILE" "$@"
+else
+    exec /usr/bin/wpe-simple-launcher --ctrl "$CTL_FILE" "$@"
+fi

--- a/recipes-browser/wpe-simple-launcher/wpe-simple-launcher_git.bb
+++ b/recipes-browser/wpe-simple-launcher/wpe-simple-launcher_git.bb
@@ -1,0 +1,24 @@
+SUMMARY = "Simple WPE-based web launcher"
+DESCRIPTION = "On-device WPEWebKit launcher that opens a URL and exposes a FIFO control channel through the wpe-ctl helper."
+HOMEPAGE = "https://github.com/psaavedra/wpe-simple-launcher"
+
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=dd93f6e0496294f589c3d561f96ffee4"
+
+inherit meson pkgconfig
+
+DEPENDS += "glib-2.0 wpewebkit"
+
+SRC_URI = "git://github.com/psaavedra/wpe-simple-launcher.git;protocol=https;branch=main;destsuffix=${BP} \
+           file://wpe-ctl \
+           file://wpe-exported-wayland \
+          "
+SRCREV = "522488025d1e68d039667bd897b3e8f4ee820061"
+
+do_install:append() {
+    install -d ${D}${bindir}
+    install -m 0755 ${B}/wpe-simple-launcher ${D}${bindir}/wpe-simple-launcher
+    install -m 0755 ${S}/wpe-ctl ${D}${bindir}/wpe-ctl
+    install -m 0755 ${S}/wpe-exported-wayland ${D}${bindir}/wpe-exported-wayland
+}
+

--- a/recipes-browser/wpe-simple-launcher/wpe-simple-launcher_git.bb
+++ b/recipes-browser/wpe-simple-launcher/wpe-simple-launcher_git.bb
@@ -18,7 +18,7 @@ SRCREV = "522488025d1e68d039667bd897b3e8f4ee820061"
 do_install:append() {
     install -d ${D}${bindir}
     install -m 0755 ${B}/wpe-simple-launcher ${D}${bindir}/wpe-simple-launcher
-    install -m 0755 ${S}/wpe-ctl ${D}${bindir}/wpe-ctl
-    install -m 0755 ${S}/wpe-exported-wayland ${D}${bindir}/wpe-exported-wayland
+    install -m 0755 ${UNPACKDIR}/wpe-ctl ${D}${bindir}/wpe-ctl
+    install -m 0755 ${UNPACKDIR}/wpe-exported-wayland ${D}${bindir}/wpe-exported-wayland
 }
 

--- a/recipes-devtools/python/python-is-python3_1.0.bb
+++ b/recipes-devtools/python/python-is-python3_1.0.bb
@@ -16,7 +16,7 @@ do_install() {
 }
 
 FILES:${PN} += "${bindir}/python"
-RDEPENDS:${PN} = "python3"
+RDEPENDS:${PN} = "python3-core"
 RCONFLICTS:${PN} = "python"
 
 BBCLASSEXTEND = "native nativesdk"


### PR DESCRIPTION
Add the wpe-simple-launcher recipe: an on-device WPEWebKit launcher that opens a URL and exposes a FIFO control channel through the wpe-ctl helper. It builds the launcher from the upstream main branch and installs the wpe-ctl and wpe-exported-wayland helper scripts.

Also added:  `python-is-python3: Depend on python3-core instead of python3` as a fix for the oe-linter.
    
    python-is-python3 only ships the python -> python3 symlink, so it needs
    just the interpreter binary provided by python3-core rather than the full
    python3 metapackage. Narrow the runtime dependency so images that only
    want the symlink do not pull in the entire python3 module set.

